### PR TITLE
feat(avai): add hot model runtime phase 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "base",
  "base_db",
  "base_rpc",
+ "ed25519-dalek",
  "gmv-domain",
  "gmv-nodec",
  "gmv-protocol",

--- a/avai/Cargo.toml
+++ b/avai/Cargo.toml
@@ -23,6 +23,7 @@ url.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+ed25519-dalek = "2"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 tower = { version = "0.5", features = ["util"] }
 #burn = "0.19"

--- a/avai/readme
+++ b/avai/readme
@@ -1,3 +1,3 @@
 Avai 使用统一服务入口：`avai start` 读取 `./config.yml`，非默认配置使用 `avai start -c <path>`；停止、状态和重启分别使用 `stop`、`status`、`restart [-c <path>]`。配置文件是唯一运行配置源，不读取环境变量覆盖。
 
-`avai::model` 提供热模型 Runtime Phase 1 基础：签名模型包校验、SQLite 不可变安装仓库、受预算约束的 preload/self-test、原子 generation 激活、在途任务引用隔离、previous rollback 与重启恢复。该阶段尚未接入现有 task/provider seam，也不包含真实 Runtime Adapter 或本地管理 UDS。
+`avai::model` 提供热模型 Runtime Phase 1 基础：签名模型包校验、安装 staging 二次校验与 SQLite 不可变安装仓库、受预算约束的 preload/self-test、串行化 lifecycle commit、原子 generation 激活、在途任务引用隔离、健康失败回滚，以及 active/previous capability slot 重启恢复。SQLite 只持久化 Installed、Ready、Active、Retired、Failed 稳定态；preloading/draining 是进程内过渡，启动时未被 previous slot 引用的 Ready 会归一为 Installed。该阶段尚未接入现有 task/provider seam，也不包含真实 Runtime Adapter 或本地管理 UDS。

--- a/avai/readme
+++ b/avai/readme
@@ -1,1 +1,3 @@
 Avai 使用统一服务入口：`avai start` 读取 `./config.yml`，非默认配置使用 `avai start -c <path>`；停止、状态和重启分别使用 `stop`、`status`、`restart [-c <path>]`。配置文件是唯一运行配置源，不读取环境变量覆盖。
+
+`avai::model` 提供热模型 Runtime Phase 1 基础：签名模型包校验、SQLite 不可变安装仓库、受预算约束的 preload/self-test、原子 generation 激活、在途任务引用隔离、previous rollback 与重启恢复。该阶段尚未接入现有 task/provider seam，也不包含真实 Runtime Adapter 或本地管理 UDS。

--- a/avai/src/lib.rs
+++ b/avai/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod guard_integration;
+pub mod model;
 pub mod source;
 pub mod task;
 pub mod upload;

--- a/avai/src/model/manager.rs
+++ b/avai/src/model/manager.rs
@@ -1,0 +1,517 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+};
+
+use base::tokio::sync::{Mutex, RwLock};
+
+use super::{
+    InferenceResult, InstalledModel, ModelError, ModelIdentity, ModelInstance, ModelRepository,
+    ModelResult, ModelState, RuntimeProvider,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct ModelManagerConfig {
+    pub max_loaded_models: usize,
+    pub max_memory_mb: u64,
+    pub max_vram_mb: u64,
+}
+
+impl Default for ModelManagerConfig {
+    fn default() -> Self {
+        Self {
+            max_loaded_models: 8,
+            max_memory_mb: 16 * 1024,
+            max_vram_mb: 16 * 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelStatus {
+    pub identity: ModelIdentity,
+    pub runtime: String,
+    pub generation: Option<u64>,
+    pub active_capabilities: Vec<String>,
+    pub in_flight_tasks: usize,
+}
+
+#[derive(Clone)]
+pub struct ModelManager {
+    repository: ModelRepository,
+    providers: Arc<HashMap<String, Arc<dyn RuntimeProvider>>>,
+    config: ModelManagerConfig,
+    loaded: Arc<Mutex<HashMap<ModelIdentity, Arc<LoadedModel>>>>,
+    slots: Arc<RwLock<HashMap<String, CapabilitySlot>>>,
+    next_generation: Arc<AtomicU64>,
+    preload_guard: Arc<Mutex<()>>,
+}
+
+struct LoadedModel {
+    model: InstalledModel,
+    instance: Arc<dyn ModelInstance>,
+    in_flight: AtomicUsize,
+}
+
+struct ModelGeneration {
+    generation: u64,
+    loaded: Arc<LoadedModel>,
+}
+
+#[derive(Default)]
+struct CapabilitySlot {
+    active: Option<Arc<ModelGeneration>>,
+    previous: Option<Arc<ModelGeneration>>,
+}
+
+pub struct ActiveModel {
+    generation: Arc<ModelGeneration>,
+}
+
+impl ActiveModel {
+    pub fn identity(&self) -> &ModelIdentity {
+        &self.generation.loaded.model.identity
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation.generation
+    }
+
+    pub async fn infer(&self, input: Vec<u8>) -> ModelResult<InferenceResult> {
+        self.generation.loaded.instance.infer(input).await
+    }
+}
+
+impl Clone for ActiveModel {
+    fn clone(&self) -> Self {
+        self.generation
+            .loaded
+            .in_flight
+            .fetch_add(1, Ordering::AcqRel);
+        Self {
+            generation: self.generation.clone(),
+        }
+    }
+}
+
+impl Drop for ActiveModel {
+    fn drop(&mut self) {
+        self.generation
+            .loaded
+            .in_flight
+            .fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+impl ModelManager {
+    pub async fn open(
+        repository: ModelRepository,
+        providers: Vec<Arc<dyn RuntimeProvider>>,
+        config: ModelManagerConfig,
+    ) -> ModelResult<Self> {
+        if config.max_loaded_models == 0 || config.max_memory_mb == 0 {
+            return Err(ModelError::new(
+                "invalid_model_manager_config",
+                "loaded model count and memory budget must be positive",
+            ));
+        }
+        let mut by_runtime = HashMap::new();
+        for provider in providers {
+            let runtime = provider.descriptor().runtime;
+            if by_runtime.insert(runtime.clone(), provider).is_some() {
+                return Err(ModelError::new(
+                    "duplicate_runtime_provider",
+                    format!("runtime provider is registered twice: {runtime}"),
+                ));
+            }
+        }
+        let next_generation = repository.max_generation().await?.saturating_add(1);
+        let manager = Self {
+            repository,
+            providers: Arc::new(by_runtime),
+            config,
+            loaded: Arc::new(Mutex::new(HashMap::new())),
+            slots: Arc::new(RwLock::new(HashMap::new())),
+            next_generation: Arc::new(AtomicU64::new(next_generation)),
+            preload_guard: Arc::new(Mutex::new(())),
+        };
+        manager.restore_active_models().await?;
+        Ok(manager)
+    }
+
+    async fn restore_active_models(&self) -> ModelResult<()> {
+        for model in self
+            .repository
+            .list()
+            .await?
+            .into_iter()
+            .filter(|model| model.state == ModelState::Active)
+        {
+            let generation = model.active_generation.ok_or_else(|| {
+                ModelError::new(
+                    "model_generation_invalid",
+                    "active model has no persisted generation",
+                )
+            })?;
+            let provider = self.providers.get(&model.runtime).ok_or_else(|| {
+                ModelError::new(
+                    "model_runtime_unavailable",
+                    format!("runtime provider is unavailable: {}", model.runtime),
+                )
+            })?;
+            self.ensure_budget(&model).await?;
+            let instance = provider.preload(&model).await?;
+            validate_instance(&model, &instance)?;
+            instance.self_test(&model.self_tests).await?;
+            instance.health().await?;
+            let loaded = Arc::new(LoadedModel {
+                model,
+                instance,
+                in_flight: AtomicUsize::new(0),
+            });
+            let active = Arc::new(ModelGeneration {
+                generation,
+                loaded: loaded.clone(),
+            });
+            let mut slots = self.slots.write().await;
+            for capability in &loaded.model.capabilities {
+                if slots
+                    .get(capability)
+                    .and_then(|slot| slot.active.as_ref())
+                    .is_some()
+                {
+                    return Err(ModelError::new(
+                        "model_active_conflict",
+                        format!("multiple active models claim capability: {capability}"),
+                    ));
+                }
+                slots.entry(capability.clone()).or_default().active = Some(active.clone());
+            }
+            drop(slots);
+            self.loaded
+                .lock()
+                .await
+                .insert(loaded.model.identity.clone(), loaded);
+        }
+        Ok(())
+    }
+
+    pub async fn preload(&self, identity: &ModelIdentity, now_epoch_ms: i64) -> ModelResult<()> {
+        let _preload_guard = self.preload_guard.lock().await;
+        if self.loaded.lock().await.contains_key(identity) {
+            return Ok(());
+        }
+        let model =
+            self.repository.get(identity).await?.ok_or_else(|| {
+                ModelError::new("model_not_found", "installed model does not exist")
+            })?;
+        let provider = self.providers.get(&model.runtime).ok_or_else(|| {
+            ModelError::new(
+                "model_runtime_unavailable",
+                format!("runtime provider is unavailable: {}", model.runtime),
+            )
+        })?;
+        self.ensure_budget(&model).await?;
+        let instance = match provider.preload(&model).await {
+            Ok(instance) => instance,
+            Err(error) => {
+                self.repository
+                    .set_state(identity, ModelState::Failed, None, now_epoch_ms)
+                    .await?;
+                return Err(error);
+            }
+        };
+        if let Err(error) = validate_instance(&model, &instance) {
+            self.repository
+                .set_state(identity, ModelState::Failed, None, now_epoch_ms)
+                .await?;
+            return Err(error);
+        }
+        if let Err(error) = instance.self_test(&model.self_tests).await {
+            self.repository
+                .set_state(identity, ModelState::Failed, None, now_epoch_ms)
+                .await?;
+            return Err(error);
+        }
+        if let Err(error) = instance.health().await {
+            self.repository
+                .set_state(identity, ModelState::Failed, None, now_epoch_ms)
+                .await?;
+            return Err(error);
+        }
+        let mut loaded = self.loaded.lock().await;
+        if loaded.contains_key(identity) {
+            return Ok(());
+        }
+        loaded.insert(
+            identity.clone(),
+            Arc::new(LoadedModel {
+                model,
+                instance,
+                in_flight: AtomicUsize::new(0),
+            }),
+        );
+        drop(loaded);
+        self.repository
+            .set_state(identity, ModelState::Ready, None, now_epoch_ms)
+            .await
+    }
+
+    pub async fn activate(&self, identity: &ModelIdentity, now_epoch_ms: i64) -> ModelResult<u64> {
+        let loaded = self
+            .loaded
+            .lock()
+            .await
+            .get(identity)
+            .cloned()
+            .ok_or_else(|| ModelError::new("model_not_ready", "model must be preloaded first"))?;
+        let mut slots = self.slots.write().await;
+        let already_active = loaded.model.capabilities.iter().all(|capability| {
+            slots
+                .get(capability)
+                .and_then(|slot| slot.active.as_ref())
+                .is_some_and(|active| active.loaded.model.identity == *identity)
+        });
+        if already_active
+            && let Some(existing) = loaded
+                .model
+                .capabilities
+                .first()
+                .and_then(|capability| slots.get(capability))
+                .and_then(|slot| slot.active.as_ref())
+        {
+            return Ok(existing.generation);
+        }
+        loaded.instance.health().await?;
+        let generation = self.next_generation.fetch_add(1, Ordering::AcqRel);
+        let replaced_capabilities = loaded.model.capabilities.iter().collect::<HashSet<_>>();
+        let no_longer_active = slots
+            .iter()
+            .filter(|(capability, _)| replaced_capabilities.contains(capability))
+            .filter_map(|(_, slot)| slot.active.as_ref())
+            .filter(|active| {
+                !slots.iter().any(|(capability, slot)| {
+                    !replaced_capabilities.contains(capability)
+                        && slot.active.as_ref().is_some_and(|candidate| {
+                            candidate.loaded.model.identity == active.loaded.model.identity
+                        })
+                })
+            })
+            .map(|active| active.loaded.model.identity.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        self.repository
+            .activate(identity, &no_longer_active, generation, now_epoch_ms)
+            .await?;
+        let active = Arc::new(ModelGeneration { generation, loaded });
+        for capability in &active.loaded.model.capabilities {
+            let slot = slots.entry(capability.clone()).or_default();
+            slot.previous = slot.active.replace(active.clone());
+        }
+        Ok(generation)
+    }
+
+    pub async fn rollback(&self, capability: &str, now_epoch_ms: i64) -> ModelResult<u64> {
+        let mut slots = self.slots.write().await;
+        let slot = slots
+            .get(capability)
+            .ok_or_else(|| ModelError::new("model_not_active", "capability has no active model"))?;
+        let previous = slot.previous.clone().ok_or_else(|| {
+            ModelError::new(
+                "model_rollback_unavailable",
+                "capability has no previous model",
+            )
+        })?;
+        let current = slot.active.clone();
+        previous.loaded.instance.health().await?;
+        let generation = self.next_generation.fetch_add(1, Ordering::AcqRel);
+        let replaced = current
+            .as_ref()
+            .filter(|active| {
+                !slots.iter().any(|(other_capability, other_slot)| {
+                    other_capability != capability
+                        && other_slot.active.as_ref().is_some_and(|candidate| {
+                            candidate.loaded.model.identity == active.loaded.model.identity
+                        })
+                })
+            })
+            .map(|active| active.loaded.model.identity.clone())
+            .into_iter()
+            .collect::<Vec<_>>();
+        self.repository
+            .activate(
+                &previous.loaded.model.identity,
+                &replaced,
+                generation,
+                now_epoch_ms,
+            )
+            .await?;
+        let restored = Arc::new(ModelGeneration {
+            generation,
+            loaded: previous.loaded.clone(),
+        });
+        let slot = slots
+            .get_mut(capability)
+            .ok_or_else(|| ModelError::new("model_not_active", "capability slot disappeared"))?;
+        let replaced = slot.active.replace(restored);
+        slot.previous = replaced;
+        Ok(generation)
+    }
+
+    pub async fn capture(&self, capability: &str) -> ModelResult<ActiveModel> {
+        let generation = self
+            .slots
+            .read()
+            .await
+            .get(capability)
+            .and_then(|slot| slot.active.clone())
+            .ok_or_else(|| ModelError::new("model_not_active", "capability has no active model"))?;
+        generation.loaded.in_flight.fetch_add(1, Ordering::AcqRel);
+        Ok(ActiveModel { generation })
+    }
+
+    pub async fn unload(&self, identity: &ModelIdentity, now_epoch_ms: i64) -> ModelResult<()> {
+        let referenced_by_slot = self.slots.read().await.values().any(|slot| {
+            slot.active
+                .as_ref()
+                .is_some_and(|value| value.loaded.model.identity == *identity)
+                || slot
+                    .previous
+                    .as_ref()
+                    .is_some_and(|value| value.loaded.model.identity == *identity)
+        });
+        if referenced_by_slot {
+            return Err(ModelError::new(
+                "model_in_use",
+                "active or previous model cannot be unloaded",
+            ));
+        }
+        let mut loaded = self.loaded.lock().await;
+        let Some(candidate) = loaded.get(identity) else {
+            return Ok(());
+        };
+        if candidate.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(ModelError::new(
+                "model_in_use",
+                "model still has in-flight tasks",
+            ));
+        }
+        loaded.remove(identity);
+        drop(loaded);
+        self.repository
+            .set_state(identity, ModelState::Installed, None, now_epoch_ms)
+            .await
+    }
+
+    pub async fn retire_previous(
+        &self,
+        capability: &str,
+        now_epoch_ms: i64,
+    ) -> ModelResult<Option<ModelIdentity>> {
+        let mut slots = self.slots.write().await;
+        let Some(slot) = slots.get_mut(capability) else {
+            return Ok(None);
+        };
+        let Some(previous) = slot.previous.as_ref() else {
+            return Ok(None);
+        };
+        if previous.loaded.in_flight.load(Ordering::Acquire) != 0 {
+            return Err(ModelError::new(
+                "model_in_use",
+                "previous model still has in-flight tasks",
+            ));
+        }
+        let identity = previous.loaded.model.identity.clone();
+        slot.previous = None;
+        drop(slots);
+        self.repository
+            .set_state(&identity, ModelState::Ready, None, now_epoch_ms)
+            .await?;
+        Ok(Some(identity))
+    }
+
+    pub async fn status(&self) -> Vec<ModelStatus> {
+        let loaded = self.loaded.lock().await;
+        let slots = self.slots.read().await;
+        loaded
+            .values()
+            .map(|loaded| {
+                let mut active_capabilities = slots
+                    .iter()
+                    .filter_map(|(capability, slot)| {
+                        slot.active
+                            .as_ref()
+                            .filter(|active| Arc::ptr_eq(&active.loaded, loaded))
+                            .map(|_| capability.clone())
+                    })
+                    .collect::<Vec<_>>();
+                active_capabilities.sort();
+                let generation = slots.values().find_map(|slot| {
+                    slot.active
+                        .as_ref()
+                        .filter(|active| Arc::ptr_eq(&active.loaded, loaded))
+                        .map(|active| active.generation)
+                });
+                ModelStatus {
+                    identity: loaded.model.identity.clone(),
+                    runtime: loaded.model.runtime.clone(),
+                    generation,
+                    active_capabilities,
+                    in_flight_tasks: loaded.in_flight.load(Ordering::Acquire),
+                }
+            })
+            .collect()
+    }
+
+    pub async fn active_identities(&self) -> HashSet<ModelIdentity> {
+        self.slots
+            .read()
+            .await
+            .values()
+            .filter_map(|slot| {
+                slot.active
+                    .as_ref()
+                    .map(|active| active.loaded.model.identity.clone())
+            })
+            .collect()
+    }
+
+    async fn ensure_budget(&self, model: &InstalledModel) -> ModelResult<()> {
+        let loaded = self.loaded.lock().await;
+        let memory_mb = loaded
+            .values()
+            .map(|loaded| loaded.model.resources.memory_mb)
+            .sum::<u64>();
+        let vram_mb = loaded
+            .values()
+            .map(|loaded| loaded.model.resources.vram_mb)
+            .sum::<u64>();
+        if loaded.len() >= self.config.max_loaded_models
+            || memory_mb.saturating_add(model.resources.memory_mb) > self.config.max_memory_mb
+            || vram_mb.saturating_add(model.resources.vram_mb) > self.config.max_vram_mb
+        {
+            return Err(ModelError::new(
+                "model_runtime_budget_exceeded",
+                "preloading this model would exceed the loaded model budget",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_instance(model: &InstalledModel, instance: &Arc<dyn ModelInstance>) -> ModelResult<()> {
+    if instance.identity() != &model.identity
+        || instance.runtime() != model.runtime
+        || instance.capabilities() != model.capabilities
+    {
+        return Err(ModelError::new(
+            "model_runtime_contract_mismatch",
+            "runtime instance metadata does not match the installed model",
+        ));
+    }
+    Ok(())
+}

--- a/avai/src/model/manager.rs
+++ b/avai/src/model/manager.rs
@@ -10,7 +10,7 @@ use base::tokio::sync::{Mutex, RwLock};
 
 use super::{
     InferenceResult, InstalledModel, ModelError, ModelIdentity, ModelInstance, ModelRepository,
-    ModelResult, ModelState, RuntimeProvider,
+    ModelResult, ModelState, RuntimeProvider, repository::PersistedCapabilitySlot,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -39,6 +39,16 @@ pub struct ModelStatus {
     pub in_flight_tasks: usize,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HealthReconcile {
+    Healthy,
+    RolledBack {
+        failed: ModelIdentity,
+        restored: ModelIdentity,
+        generation: u64,
+    },
+}
+
 #[derive(Clone)]
 pub struct ModelManager {
     repository: ModelRepository,
@@ -47,7 +57,7 @@ pub struct ModelManager {
     loaded: Arc<Mutex<HashMap<ModelIdentity, Arc<LoadedModel>>>>,
     slots: Arc<RwLock<HashMap<String, CapabilitySlot>>>,
     next_generation: Arc<AtomicU64>,
-    preload_guard: Arc<Mutex<()>>,
+    lifecycle: Arc<Mutex<()>>,
 }
 
 struct LoadedModel {
@@ -136,71 +146,121 @@ impl ModelManager {
             loaded: Arc::new(Mutex::new(HashMap::new())),
             slots: Arc::new(RwLock::new(HashMap::new())),
             next_generation: Arc::new(AtomicU64::new(next_generation)),
-            preload_guard: Arc::new(Mutex::new(())),
+            lifecycle: Arc::new(Mutex::new(())),
         };
-        manager.restore_active_models().await?;
+        manager.restore_capability_slots().await?;
         Ok(manager)
     }
 
-    async fn restore_active_models(&self) -> ModelResult<()> {
-        for model in self
-            .repository
-            .list()
-            .await?
-            .into_iter()
-            .filter(|model| model.state == ModelState::Active)
-        {
-            let generation = model.active_generation.ok_or_else(|| {
-                ModelError::new(
-                    "model_generation_invalid",
-                    "active model has no persisted generation",
-                )
-            })?;
-            let provider = self.providers.get(&model.runtime).ok_or_else(|| {
-                ModelError::new(
-                    "model_runtime_unavailable",
-                    format!("runtime provider is unavailable: {}", model.runtime),
-                )
-            })?;
-            self.ensure_budget(&model).await?;
-            let instance = provider.preload(&model).await?;
-            validate_instance(&model, &instance)?;
-            instance.self_test(&model.self_tests).await?;
-            instance.health().await?;
-            let loaded = Arc::new(LoadedModel {
-                model,
-                instance,
-                in_flight: AtomicUsize::new(0),
-            });
-            let active = Arc::new(ModelGeneration {
-                generation,
-                loaded: loaded.clone(),
-            });
-            let mut slots = self.slots.write().await;
-            for capability in &loaded.model.capabilities {
-                if slots
-                    .get(capability)
-                    .and_then(|slot| slot.active.as_ref())
-                    .is_some()
-                {
+    async fn restore_capability_slots(&self) -> ModelResult<()> {
+        self.repository.reconcile_unreferenced_ready().await?;
+        let persisted = self.repository.list_slots().await?;
+        let models = self.repository.list().await?;
+        let active_identities = persisted
+            .iter()
+            .map(|slot| slot.active_identity.clone())
+            .collect::<HashSet<_>>();
+        if models.iter().any(|model| {
+            model.state == ModelState::Active && !active_identities.contains(&model.identity)
+        }) {
+            return Err(ModelError::new(
+                "model_slot_invalid",
+                "active model has no persisted capability slot",
+            ));
+        }
+        for slot in persisted {
+            let active = self
+                .restore_generation(&slot.active_identity, slot.active_generation)
+                .await?;
+            if active.loaded.model.state != ModelState::Active {
+                return Err(ModelError::new(
+                    "model_slot_invalid",
+                    "persisted active slot references a model that is not active",
+                ));
+            }
+            if !active.loaded.model.capabilities.contains(&slot.capability) {
+                return Err(ModelError::new(
+                    "model_slot_invalid",
+                    "active model does not provide persisted capability",
+                ));
+            }
+            let previous = match (&slot.previous_identity, slot.previous_generation) {
+                (Some(identity), Some(generation)) => {
+                    let previous = self.restore_generation(identity, generation).await?;
+                    if !previous
+                        .loaded
+                        .model
+                        .capabilities
+                        .contains(&slot.capability)
+                    {
+                        return Err(ModelError::new(
+                            "model_slot_invalid",
+                            "previous model does not provide persisted capability",
+                        ));
+                    }
+                    Some(previous)
+                }
+                (None, None) => None,
+                _ => {
                     return Err(ModelError::new(
-                        "model_active_conflict",
-                        format!("multiple active models claim capability: {capability}"),
+                        "model_slot_invalid",
+                        "previous model slot is incomplete",
                     ));
                 }
-                slots.entry(capability.clone()).or_default().active = Some(active.clone());
-            }
-            drop(slots);
-            self.loaded
-                .lock()
-                .await
-                .insert(loaded.model.identity.clone(), loaded);
+            };
+            self.slots.write().await.insert(
+                slot.capability,
+                CapabilitySlot {
+                    active: Some(active),
+                    previous,
+                },
+            );
         }
         Ok(())
     }
 
+    async fn restore_generation(
+        &self,
+        identity: &ModelIdentity,
+        generation: u64,
+    ) -> ModelResult<Arc<ModelGeneration>> {
+        if let Some(loaded) = self.loaded.lock().await.get(identity).cloned() {
+            return Ok(Arc::new(ModelGeneration { generation, loaded }));
+        }
+        let model = self.repository.get(identity).await?.ok_or_else(|| {
+            ModelError::new("model_slot_invalid", "persisted slot model does not exist")
+        })?;
+        if !matches!(model.state, ModelState::Active | ModelState::Ready) {
+            return Err(ModelError::new(
+                "model_slot_invalid",
+                "persisted slot references a model that is not active or ready",
+            ));
+        }
+        let provider = self.providers.get(&model.runtime).ok_or_else(|| {
+            ModelError::new(
+                "model_runtime_unavailable",
+                format!("runtime provider is unavailable: {}", model.runtime),
+            )
+        })?;
+        self.ensure_budget(&model).await?;
+        let instance = provider.preload(&model).await?;
+        validate_instance(&model, &instance)?;
+        instance.self_test(&model.self_tests).await?;
+        instance.health().await?;
+        let loaded = Arc::new(LoadedModel {
+            model,
+            instance,
+            in_flight: AtomicUsize::new(0),
+        });
+        self.loaded
+            .lock()
+            .await
+            .insert(identity.clone(), loaded.clone());
+        Ok(Arc::new(ModelGeneration { generation, loaded }))
+    }
+
     pub async fn preload(&self, identity: &ModelIdentity, now_epoch_ms: i64) -> ModelResult<()> {
-        let _preload_guard = self.preload_guard.lock().await;
+        let _lifecycle = self.lifecycle.lock().await;
         if self.loaded.lock().await.contains_key(identity) {
             return Ok(());
         }
@@ -242,11 +302,10 @@ impl ModelManager {
                 .await?;
             return Err(error);
         }
-        let mut loaded = self.loaded.lock().await;
-        if loaded.contains_key(identity) {
-            return Ok(());
-        }
-        loaded.insert(
+        self.repository
+            .set_state(identity, ModelState::Ready, None, now_epoch_ms)
+            .await?;
+        self.loaded.lock().await.insert(
             identity.clone(),
             Arc::new(LoadedModel {
                 model,
@@ -254,13 +313,11 @@ impl ModelManager {
                 in_flight: AtomicUsize::new(0),
             }),
         );
-        drop(loaded);
-        self.repository
-            .set_state(identity, ModelState::Ready, None, now_epoch_ms)
-            .await
+        Ok(())
     }
 
     pub async fn activate(&self, identity: &ModelIdentity, now_epoch_ms: i64) -> ModelResult<u64> {
+        let _lifecycle = self.lifecycle.lock().await;
         let loaded = self
             .loaded
             .lock()
@@ -268,7 +325,7 @@ impl ModelManager {
             .get(identity)
             .cloned()
             .ok_or_else(|| ModelError::new("model_not_ready", "model must be preloaded first"))?;
-        let mut slots = self.slots.write().await;
+        let slots = self.slots.write().await;
         let already_active = loaded.model.capabilities.iter().all(|capability| {
             slots
                 .get(capability)
@@ -285,7 +342,9 @@ impl ModelManager {
         {
             return Ok(existing.generation);
         }
+        drop(slots);
         loaded.instance.health().await?;
+        let mut slots = self.slots.write().await;
         let generation = self.next_generation.fetch_add(1, Ordering::AcqRel);
         let replaced_capabilities = loaded.model.capabilities.iter().collect::<HashSet<_>>();
         let no_longer_active = slots
@@ -304,8 +363,31 @@ impl ModelManager {
             .collect::<HashSet<_>>()
             .into_iter()
             .collect::<Vec<_>>();
+        let persisted_slots = loaded
+            .model
+            .capabilities
+            .iter()
+            .map(|capability| {
+                let previous = slots.get(capability).and_then(|slot| slot.active.as_ref());
+                PersistedCapabilitySlot {
+                    capability: capability.clone(),
+                    active_identity: identity.clone(),
+                    active_generation: generation,
+                    previous_identity: previous
+                        .map(|generation| generation.loaded.model.identity.clone()),
+                    previous_generation: previous.map(|generation| generation.generation),
+                }
+            })
+            .collect::<Vec<_>>();
         self.repository
-            .activate(identity, &no_longer_active, generation, now_epoch_ms)
+            .activate(
+                identity,
+                &no_longer_active,
+                &[],
+                &persisted_slots,
+                generation,
+                now_epoch_ms,
+            )
             .await?;
         let active = Arc::new(ModelGeneration { generation, loaded });
         for capability in &active.loaded.model.capabilities {
@@ -316,6 +398,16 @@ impl ModelManager {
     }
 
     pub async fn rollback(&self, capability: &str, now_epoch_ms: i64) -> ModelResult<u64> {
+        let _lifecycle = self.lifecycle.lock().await;
+        self.rollback_locked(capability, now_epoch_ms, false).await
+    }
+
+    async fn rollback_locked(
+        &self,
+        capability: &str,
+        now_epoch_ms: i64,
+        failed_current: bool,
+    ) -> ModelResult<u64> {
         let mut slots = self.slots.write().await;
         let slot = slots
             .get(capability)
@@ -342,10 +434,34 @@ impl ModelManager {
             .map(|active| active.loaded.model.identity.clone())
             .into_iter()
             .collect::<Vec<_>>();
+        let persisted_slot = PersistedCapabilitySlot {
+            capability: capability.to_string(),
+            active_identity: previous.loaded.model.identity.clone(),
+            active_generation: generation,
+            previous_identity: (!failed_current)
+                .then_some(current.as_ref())
+                .flatten()
+                .map(|generation| generation.loaded.model.identity.clone()),
+            previous_generation: (!failed_current)
+                .then_some(current.as_ref())
+                .flatten()
+                .map(|generation| generation.generation),
+        };
+        let failed_models = if failed_current {
+            current
+                .as_ref()
+                .map(|generation| generation.loaded.model.identity.clone())
+                .into_iter()
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
         self.repository
             .activate(
                 &previous.loaded.model.identity,
                 &replaced,
+                &failed_models,
+                &[persisted_slot],
                 generation,
                 now_epoch_ms,
             )
@@ -358,7 +474,7 @@ impl ModelManager {
             .get_mut(capability)
             .ok_or_else(|| ModelError::new("model_not_active", "capability slot disappeared"))?;
         let replaced = slot.active.replace(restored);
-        slot.previous = replaced;
+        slot.previous = (!failed_current).then_some(replaced).flatten();
         Ok(generation)
     }
 
@@ -375,6 +491,7 @@ impl ModelManager {
     }
 
     pub async fn unload(&self, identity: &ModelIdentity, now_epoch_ms: i64) -> ModelResult<()> {
+        let _lifecycle = self.lifecycle.lock().await;
         let referenced_by_slot = self.slots.read().await.values().any(|slot| {
             slot.active
                 .as_ref()
@@ -400,18 +517,19 @@ impl ModelManager {
                 "model still has in-flight tasks",
             ));
         }
-        loaded.remove(identity);
-        drop(loaded);
         self.repository
             .set_state(identity, ModelState::Installed, None, now_epoch_ms)
-            .await
+            .await?;
+        loaded.remove(identity);
+        Ok(())
     }
 
     pub async fn retire_previous(
         &self,
         capability: &str,
-        now_epoch_ms: i64,
+        _now_epoch_ms: i64,
     ) -> ModelResult<Option<ModelIdentity>> {
+        let _lifecycle = self.lifecycle.lock().await;
         let mut slots = self.slots.write().await;
         let Some(slot) = slots.get_mut(capability) else {
             return Ok(None);
@@ -426,12 +544,42 @@ impl ModelManager {
             ));
         }
         let identity = previous.loaded.model.identity.clone();
+        self.repository.clear_previous(capability).await?;
         slot.previous = None;
-        drop(slots);
-        self.repository
-            .set_state(&identity, ModelState::Ready, None, now_epoch_ms)
-            .await?;
         Ok(Some(identity))
+    }
+
+    pub async fn reconcile_active_health(
+        &self,
+        capability: &str,
+        now_epoch_ms: i64,
+    ) -> ModelResult<HealthReconcile> {
+        let _lifecycle = self.lifecycle.lock().await;
+        let active = self
+            .slots
+            .read()
+            .await
+            .get(capability)
+            .and_then(|slot| slot.active.clone())
+            .ok_or_else(|| ModelError::new("model_not_active", "capability has no active model"))?;
+        if active.loaded.instance.health().await.is_ok() {
+            return Ok(HealthReconcile::Healthy);
+        }
+        let failed = active.loaded.model.identity.clone();
+        let generation = self.rollback_locked(capability, now_epoch_ms, true).await?;
+        let restored = self
+            .slots
+            .read()
+            .await
+            .get(capability)
+            .and_then(|slot| slot.active.as_ref())
+            .map(|active| active.loaded.model.identity.clone())
+            .ok_or_else(|| ModelError::new("model_not_active", "rollback did not restore model"))?;
+        Ok(HealthReconcile::RolledBack {
+            failed,
+            restored,
+            generation,
+        })
     }
 
     pub async fn status(&self) -> Vec<ModelStatus> {

--- a/avai/src/model/mod.rs
+++ b/avai/src/model/mod.rs
@@ -3,7 +3,7 @@ mod package;
 mod repository;
 mod runtime;
 
-pub use manager::{ActiveModel, ModelManager, ModelManagerConfig, ModelStatus};
+pub use manager::{ActiveModel, HealthReconcile, ModelManager, ModelManagerConfig, ModelStatus};
 pub use package::{
     LicenseSpec, ModelFile, ModelIdentity, ModelPackageManifest, PackagePolicy, ResourceHints,
     ResultSchema, RuntimeVariant, SelfTestCase, SigningSpec, VerifiedModelPackage,

--- a/avai/src/model/mod.rs
+++ b/avai/src/model/mod.rs
@@ -1,0 +1,45 @@
+mod manager;
+mod package;
+mod repository;
+mod runtime;
+
+pub use manager::{ActiveModel, ModelManager, ModelManagerConfig, ModelStatus};
+pub use package::{
+    LicenseSpec, ModelFile, ModelIdentity, ModelPackageManifest, PackagePolicy, ResourceHints,
+    ResultSchema, RuntimeVariant, SelfTestCase, SigningSpec, VerifiedModelPackage,
+    model_package_signing_payload, verify_package,
+};
+pub use repository::{InstalledModel, ModelRepository, ModelState};
+pub use runtime::{
+    FakeRuntimeBehavior, FakeRuntimeProvider, InferenceResult, ModelInstance, RuntimeDescriptor,
+    RuntimeProvider,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl ModelError {
+    pub(crate) fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn io(stage: &'static str, error: impl std::fmt::Display) -> Self {
+        Self::new("model_io_failed", format!("{stage}: {error}"))
+    }
+}
+
+impl std::fmt::Display for ModelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ModelError {}
+
+pub type ModelResult<T> = Result<T, ModelError>;

--- a/avai/src/model/package.rs
+++ b/avai/src/model/package.rs
@@ -1,0 +1,439 @@
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Component, Path, PathBuf},
+};
+
+use base::{
+    base64::Engine,
+    serde::{Deserialize, Serialize},
+    sha2::{Digest, Sha256},
+};
+
+use super::{ModelError, ModelResult};
+
+const MANIFEST_FILE: &str = "manifest.yaml";
+const API_VERSION: &str = "gmv.ai/v1";
+const PACKAGE_KIND: &str = "ModelPlugin";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct ModelIdentity {
+    pub model_id: String,
+    pub version: String,
+    pub revision: String,
+}
+
+impl ModelIdentity {
+    pub fn actual_model(&self, runtime: impl Into<String>) -> gmv_protocol::avai::v1::ModelRef {
+        gmv_protocol::avai::v1::ModelRef {
+            model_id: self.model_id.clone(),
+            version: self.version.clone(),
+            runtime: runtime.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct ModelPackageManifest {
+    pub api_version: String,
+    pub kind: String,
+    pub metadata: ModelIdentity,
+    pub capabilities: Vec<String>,
+    pub result_schema: ResultSchema,
+    pub variants: Vec<RuntimeVariant>,
+    pub resources: ResourceHints,
+    pub license: LicenseSpec,
+    #[serde(default)]
+    pub self_test: Vec<SelfTestCase>,
+    pub files: Vec<ModelFile>,
+    pub signing: SigningSpec,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct ResultSchema {
+    pub name: String,
+    pub version: u32,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct RuntimeVariant {
+    pub runtime: String,
+    pub architecture: String,
+    #[serde(default)]
+    pub accelerator: String,
+    pub artifact: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct ResourceHints {
+    pub memory_mb: u64,
+    #[serde(default)]
+    pub vram_mb: u64,
+    pub max_batch: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct LicenseSpec {
+    pub spdx: String,
+    pub commercial_use: bool,
+    pub redistribution: String,
+    #[serde(default)]
+    pub license_ref: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct SelfTestCase {
+    pub input: String,
+    pub expected: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct ModelFile {
+    pub path: String,
+    pub sha256: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(crate = "base::serde", deny_unknown_fields)]
+pub struct SigningSpec {
+    pub key_id: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PackagePolicy {
+    pub architecture: String,
+    pub available_runtimes: HashSet<String>,
+    pub available_accelerators: HashSet<String>,
+    pub allowed_result_schemas: HashSet<(String, u32)>,
+    pub approved_spdx: HashSet<String>,
+    pub available_license_refs: HashSet<String>,
+    pub trusted_signing_keys: HashMap<String, Vec<u8>>,
+    pub max_manifest_bytes: u64,
+    pub max_file_count: usize,
+    pub max_package_bytes: u64,
+    pub max_memory_mb: u64,
+    pub max_vram_mb: u64,
+}
+
+impl Default for PackagePolicy {
+    fn default() -> Self {
+        Self {
+            architecture: std::env::consts::ARCH.to_string(),
+            available_runtimes: HashSet::new(),
+            available_accelerators: HashSet::from(["cpu".to_string()]),
+            allowed_result_schemas: HashSet::new(),
+            approved_spdx: HashSet::new(),
+            available_license_refs: HashSet::new(),
+            trusted_signing_keys: HashMap::new(),
+            max_manifest_bytes: 256 * 1024,
+            max_file_count: 256,
+            max_package_bytes: 4 * 1024 * 1024 * 1024,
+            max_memory_mb: 16 * 1024,
+            max_vram_mb: 16 * 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct VerifiedModelPackage {
+    pub root: PathBuf,
+    pub manifest: ModelPackageManifest,
+    pub selected_variant: RuntimeVariant,
+    pub manifest_sha256: String,
+}
+
+pub fn verify_package(root: &Path, policy: &PackagePolicy) -> ModelResult<VerifiedModelPackage> {
+    let root_metadata = std::fs::symlink_metadata(root)
+        .map_err(|error| ModelError::io("inspect package root", error))?;
+    if !root_metadata.is_dir() || root_metadata.file_type().is_symlink() {
+        return Err(ModelError::new(
+            "invalid_model_package",
+            "package root must be a real directory",
+        ));
+    }
+    let manifest_path = root.join(MANIFEST_FILE);
+    let manifest_metadata = regular_file_metadata(&manifest_path)?;
+    if manifest_metadata.len() > policy.max_manifest_bytes {
+        return Err(ModelError::new(
+            "model_package_too_large",
+            "manifest exceeds configured size limit",
+        ));
+    }
+    let manifest_bytes = std::fs::read(&manifest_path)
+        .map_err(|error| ModelError::io("read model manifest", error))?;
+    let manifest: ModelPackageManifest = base::serde_yaml::from_slice(&manifest_bytes)
+        .map_err(|error| ModelError::new("invalid_model_manifest", error.to_string()))?;
+    validate_manifest(&manifest, policy)?;
+    verify_signature(&manifest, policy)?;
+    if manifest.files.len() > policy.max_file_count {
+        return Err(ModelError::new(
+            "model_package_too_large",
+            "package contains too many files",
+        ));
+    }
+
+    let mut paths = HashSet::new();
+    let mut total_bytes = manifest_metadata.len();
+    for file in &manifest.files {
+        let relative = safe_relative_path(&file.path)?;
+        if !paths.insert(relative.clone()) {
+            return Err(ModelError::new(
+                "invalid_model_manifest",
+                format!("duplicate file entry: {}", file.path),
+            ));
+        }
+        let path = root.join(&relative);
+        let metadata = confined_regular_file_metadata(root, &relative)?;
+        if metadata.len() != file.size {
+            return Err(ModelError::new(
+                "model_file_size_mismatch",
+                format!("model file size mismatch: {}", file.path),
+            ));
+        }
+        total_bytes = total_bytes.checked_add(metadata.len()).ok_or_else(|| {
+            ModelError::new("model_package_too_large", "package byte count overflow")
+        })?;
+        if total_bytes > policy.max_package_bytes {
+            return Err(ModelError::new(
+                "model_package_too_large",
+                "package exceeds configured byte limit",
+            ));
+        }
+        let bytes = std::fs::read(&path)
+            .map_err(|error| ModelError::io("read model package file", error))?;
+        let actual = format!("{:x}", Sha256::digest(bytes));
+        if !actual.eq_ignore_ascii_case(file.sha256.trim_start_matches("sha256:")) {
+            return Err(ModelError::new(
+                "model_file_hash_mismatch",
+                format!("model file hash mismatch: {}", file.path),
+            ));
+        }
+    }
+    let required_paths = std::iter::once(&manifest.result_schema.path)
+        .chain(manifest.variants.iter().map(|variant| &variant.artifact))
+        .chain(
+            manifest
+                .self_test
+                .iter()
+                .flat_map(|case| [&case.input, &case.expected]),
+        );
+    for required in required_paths {
+        let required = safe_relative_path(required)?;
+        if !paths.contains(&required) {
+            return Err(ModelError::new(
+                "invalid_model_manifest",
+                format!("required file is not hash-declared: {}", required.display()),
+            ));
+        }
+    }
+    let schema_bytes = std::fs::read(root.join(safe_relative_path(&manifest.result_schema.path)?))
+        .map_err(|error| ModelError::io("read result schema", error))?;
+    base::serde_json::from_slice::<base::serde_json::Value>(&schema_bytes).map_err(|error| {
+        ModelError::new(
+            "invalid_result_schema",
+            format!("model result schema is invalid JSON: {error}"),
+        )
+    })?;
+
+    let selected_variant = manifest
+        .variants
+        .iter()
+        .find(|variant| {
+            variant.architecture == policy.architecture
+                && policy.available_runtimes.contains(&variant.runtime)
+                && (variant.accelerator.is_empty()
+                    || policy.available_accelerators.contains(&variant.accelerator))
+        })
+        .cloned()
+        .ok_or_else(|| {
+            ModelError::new(
+                "model_runtime_incompatible",
+                "no model variant matches this architecture and available runtime",
+            )
+        })?;
+    Ok(VerifiedModelPackage {
+        root: root.to_path_buf(),
+        manifest,
+        selected_variant,
+        manifest_sha256: format!("{:x}", Sha256::digest(manifest_bytes)),
+    })
+}
+
+fn validate_manifest(manifest: &ModelPackageManifest, policy: &PackagePolicy) -> ModelResult<()> {
+    if manifest.api_version != API_VERSION || manifest.kind != PACKAGE_KIND {
+        return Err(ModelError::new(
+            "unsupported_model_schema",
+            "unsupported model package api_version or kind",
+        ));
+    }
+    for value in [
+        &manifest.metadata.model_id,
+        &manifest.metadata.version,
+        &manifest.metadata.revision,
+    ] {
+        validate_identifier(value)?;
+    }
+    if manifest.capabilities.is_empty()
+        || manifest
+            .capabilities
+            .iter()
+            .any(|value| value.trim().is_empty())
+        || manifest.variants.is_empty()
+        || manifest.files.is_empty()
+    {
+        return Err(ModelError::new(
+            "invalid_model_manifest",
+            "capabilities, variants and files must not be empty",
+        ));
+    }
+    if !policy.allowed_result_schemas.contains(&(
+        manifest.result_schema.name.clone(),
+        manifest.result_schema.version,
+    )) {
+        return Err(ModelError::new(
+            "unsupported_result_schema",
+            "model result schema is not allowed",
+        ));
+    }
+    if !policy.approved_spdx.contains(&manifest.license.spdx)
+        || (!manifest.license.license_ref.is_empty()
+            && !policy
+                .available_license_refs
+                .contains(&manifest.license.license_ref))
+    {
+        return Err(ModelError::new(
+            "model_license_unavailable",
+            "model license is unavailable or not approved",
+        ));
+    }
+    if !policy
+        .trusted_signing_keys
+        .contains_key(&manifest.signing.key_id)
+        || manifest.signing.signature.trim().is_empty()
+    {
+        return Err(ModelError::new(
+            "model_signature_untrusted",
+            "model package signing metadata is missing or untrusted",
+        ));
+    }
+    if manifest.resources.memory_mb > policy.max_memory_mb
+        || manifest.resources.vram_mb > policy.max_vram_mb
+        || manifest.resources.max_batch == 0
+    {
+        return Err(ModelError::new(
+            "model_resource_limit_exceeded",
+            "model resource hints exceed configured limits",
+        ));
+    }
+    Ok(())
+}
+
+pub fn model_package_signing_payload(manifest: &ModelPackageManifest) -> ModelResult<Vec<u8>> {
+    let mut unsigned = manifest.clone();
+    unsigned.signing.signature.clear();
+    base::serde_json::to_vec(&unsigned)
+        .map_err(|error| ModelError::new("invalid_model_manifest", error.to_string()))
+}
+
+fn verify_signature(manifest: &ModelPackageManifest, policy: &PackagePolicy) -> ModelResult<()> {
+    let public_key = policy
+        .trusted_signing_keys
+        .get(&manifest.signing.key_id)
+        .ok_or_else(|| {
+            ModelError::new(
+                "model_signature_untrusted",
+                "model package signing key is not trusted",
+            )
+        })?;
+    let signature = base::base64::engine::general_purpose::STANDARD
+        .decode(&manifest.signing.signature)
+        .map_err(|_| {
+            ModelError::new(
+                "model_signature_invalid",
+                "model package signature is not valid base64",
+            )
+        })?;
+    let payload = model_package_signing_payload(manifest)?;
+    base::artifact::verify_ed25519(&payload, public_key, &signature).map_err(|_| {
+        ModelError::new(
+            "model_signature_invalid",
+            "model package signature verification failed",
+        )
+    })
+}
+
+fn validate_identifier(value: &str) -> ModelResult<()> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b':'))
+    {
+        return Err(ModelError::new(
+            "invalid_model_manifest",
+            "model identity contains an unsafe value",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn safe_relative_path(value: &str) -> ModelResult<PathBuf> {
+    let path = Path::new(value);
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(ModelError::new(
+            "model_path_invalid",
+            format!("model package path is not confined: {value}"),
+        ));
+    }
+    Ok(path.to_path_buf())
+}
+
+fn regular_file_metadata(path: &Path) -> ModelResult<std::fs::Metadata> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| ModelError::io("inspect model package file", error))?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(ModelError::new(
+            "invalid_model_package",
+            format!("package entry is not a regular file: {}", path.display()),
+        ));
+    }
+    Ok(metadata)
+}
+
+fn confined_regular_file_metadata(root: &Path, relative: &Path) -> ModelResult<std::fs::Metadata> {
+    let mut current = root.to_path_buf();
+    let component_count = relative.components().count();
+    for (index, component) in relative.components().enumerate() {
+        current.push(component.as_os_str());
+        let metadata = std::fs::symlink_metadata(&current)
+            .map_err(|error| ModelError::io("inspect model package path", error))?;
+        if metadata.file_type().is_symlink()
+            || (index + 1 < component_count && !metadata.is_dir())
+            || (index + 1 == component_count && !metadata.is_file())
+        {
+            return Err(ModelError::new(
+                "invalid_model_package",
+                format!(
+                    "package path is not a confined regular file: {}",
+                    current.display()
+                ),
+            ));
+        }
+    }
+    regular_file_metadata(&current)
+}

--- a/avai/src/model/package.rs
+++ b/avai/src/model/package.rs
@@ -150,6 +150,24 @@ pub struct VerifiedModelPackage {
     pub manifest: ModelPackageManifest,
     pub selected_variant: RuntimeVariant,
     pub manifest_sha256: String,
+    policy: PackagePolicy,
+}
+
+impl VerifiedModelPackage {
+    pub(crate) fn verify_staged_copy(&self, root: &Path) -> ModelResult<()> {
+        let staged = verify_package(root, &self.policy)?;
+        if staged.manifest.metadata != self.manifest.metadata
+            || staged.manifest_sha256 != self.manifest_sha256
+            || staged.selected_variant.runtime != self.selected_variant.runtime
+            || staged.selected_variant.artifact != self.selected_variant.artifact
+        {
+            return Err(ModelError::new(
+                "model_package_changed",
+                "model package changed after verification",
+            ));
+        }
+        Ok(())
+    }
 }
 
 pub fn verify_package(root: &Path, policy: &PackagePolicy) -> ModelResult<VerifiedModelPackage> {
@@ -266,6 +284,7 @@ pub fn verify_package(root: &Path, policy: &PackagePolicy) -> ModelResult<Verifi
         manifest,
         selected_variant,
         manifest_sha256: format!("{:x}", Sha256::digest(manifest_bytes)),
+        policy: policy.clone(),
     })
 }
 

--- a/avai/src/model/repository.rs
+++ b/avai/src/model/repository.rs
@@ -53,6 +53,15 @@ pub struct InstalledModel {
     pub active_generation: Option<u64>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PersistedCapabilitySlot {
+    pub capability: String,
+    pub active_identity: ModelIdentity,
+    pub active_generation: u64,
+    pub previous_identity: Option<ModelIdentity>,
+    pub previous_generation: Option<u64>,
+}
+
 #[derive(Clone)]
 pub struct ModelRepository {
     pool: SqlitePool,
@@ -104,6 +113,22 @@ impl ModelRepository {
         .execute(&pool)
         .await
         .map_err(|error| ModelError::io("initialize model schema", error))?;
+        base_db::sqlx::query(
+            "CREATE TABLE IF NOT EXISTS avai_model_capability_slot (\
+             capability TEXT NOT NULL PRIMARY KEY,\
+             active_model_id TEXT NOT NULL,\
+             active_version TEXT NOT NULL,\
+             active_revision TEXT NOT NULL,\
+             active_generation INTEGER NOT NULL,\
+             previous_model_id TEXT NULL,\
+             previous_version TEXT NULL,\
+             previous_revision TEXT NULL,\
+             previous_generation INTEGER NULL\
+             )",
+        )
+        .execute(&pool)
+        .await
+        .map_err(|error| ModelError::io("initialize model slot schema", error))?;
         Ok(Self {
             pool,
             packages_root: Arc::new(packages_root),
@@ -162,6 +187,7 @@ impl ModelRepository {
                 let relative = safe_relative_path(&file.path)?;
                 copy_confined_file(&package.root, &relative, &staging.join(&relative))?;
             }
+            package.verify_staged_copy(&staging)?;
             if let Some(parent) = destination.parent() {
                 create_directory(parent)?;
             }
@@ -245,7 +271,10 @@ impl ModelRepository {
 
     pub(crate) async fn max_generation(&self) -> ModelResult<u64> {
         let value: i64 = base_db::sqlx::query_scalar(
-            "SELECT COALESCE(MAX(active_generation), 0) FROM avai_model_revision",
+            "SELECT COALESCE(MAX(generation), 0) FROM (\
+             SELECT active_generation AS generation FROM avai_model_capability_slot \
+             UNION ALL SELECT previous_generation FROM avai_model_capability_slot\
+             )",
         )
         .fetch_one(&self.pool)
         .await
@@ -291,6 +320,8 @@ impl ModelRepository {
         &self,
         identity: &ModelIdentity,
         no_longer_active: &[ModelIdentity],
+        failed_models: &[ModelIdentity],
+        slots: &[PersistedCapabilitySlot],
         generation: u64,
         now_epoch_ms: i64,
     ) -> ModelResult<()> {
@@ -313,6 +344,19 @@ impl ModelRepository {
             .await
             .map_err(|error| ModelError::io("persist previous model state", error))?;
         }
+        for failed in failed_models {
+            base_db::sqlx::query(
+                "UPDATE avai_model_revision SET state=?,active_generation=NULL,last_error=? WHERE model_id=? AND version=? AND revision=?",
+            )
+            .bind(ModelState::Failed as i32)
+            .bind("active health check failed")
+            .bind(&failed.model_id)
+            .bind(&failed.version)
+            .bind(&failed.revision)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|error| ModelError::io("persist failed active model state", error))?;
+        }
         let updated = base_db::sqlx::query(
             "UPDATE avai_model_revision SET state=?, active_generation=?, activated_at_ms=?, last_error=NULL WHERE model_id=? AND version=? AND revision=?",
         )
@@ -331,10 +375,97 @@ impl ModelRepository {
                 "installed model does not exist",
             ));
         }
+        for slot in slots {
+            let active_generation = i64::try_from(slot.active_generation).map_err(|_| {
+                ModelError::new("model_generation_invalid", "generation is too large")
+            })?;
+            let previous_generation = slot
+                .previous_generation
+                .map(i64::try_from)
+                .transpose()
+                .map_err(|_| {
+                    ModelError::new("model_generation_invalid", "generation is too large")
+                })?;
+            base_db::sqlx::query(
+                "INSERT INTO avai_model_capability_slot(\
+                 capability,active_model_id,active_version,active_revision,active_generation,\
+                 previous_model_id,previous_version,previous_revision,previous_generation\
+                 ) VALUES(?,?,?,?,?,?,?,?,?) ON CONFLICT(capability) DO UPDATE SET \
+                 active_model_id=excluded.active_model_id,active_version=excluded.active_version,\
+                 active_revision=excluded.active_revision,active_generation=excluded.active_generation,\
+                 previous_model_id=excluded.previous_model_id,previous_version=excluded.previous_version,\
+                 previous_revision=excluded.previous_revision,previous_generation=excluded.previous_generation",
+            )
+            .bind(&slot.capability)
+            .bind(&slot.active_identity.model_id)
+            .bind(&slot.active_identity.version)
+            .bind(&slot.active_identity.revision)
+            .bind(active_generation)
+            .bind(
+                slot.previous_identity
+                    .as_ref()
+                    .map(|identity| &identity.model_id),
+            )
+            .bind(
+                slot.previous_identity
+                    .as_ref()
+                    .map(|identity| &identity.version),
+            )
+            .bind(
+                slot.previous_identity
+                    .as_ref()
+                    .map(|identity| &identity.revision),
+            )
+            .bind(previous_generation)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|error| ModelError::io("persist model capability slot", error))?;
+        }
         transaction
             .commit()
             .await
             .map_err(|error| ModelError::io("commit model activation", error))
+    }
+
+    pub(crate) async fn list_slots(&self) -> ModelResult<Vec<PersistedCapabilitySlot>> {
+        let rows = base_db::sqlx::query(
+            "SELECT capability,active_model_id,active_version,active_revision,active_generation,\
+             previous_model_id,previous_version,previous_revision,previous_generation \
+             FROM avai_model_capability_slot ORDER BY capability",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|error| ModelError::io("list model capability slots", error))?;
+        rows.into_iter().map(decode_slot).collect()
+    }
+
+    pub(crate) async fn clear_previous(&self, capability: &str) -> ModelResult<()> {
+        base_db::sqlx::query(
+            "UPDATE avai_model_capability_slot SET previous_model_id=NULL,previous_version=NULL,\
+             previous_revision=NULL,previous_generation=NULL WHERE capability=?",
+        )
+        .bind(capability)
+        .execute(&self.pool)
+        .await
+        .map_err(|error| ModelError::io("retire previous model slot", error))?;
+        Ok(())
+    }
+
+    pub(crate) async fn reconcile_unreferenced_ready(&self) -> ModelResult<()> {
+        base_db::sqlx::query(
+            "UPDATE avai_model_revision SET state=?,active_generation=NULL WHERE state=? AND NOT EXISTS (\
+             SELECT 1 FROM avai_model_capability_slot slot WHERE \
+             slot.previous_model_id=avai_model_revision.model_id AND \
+             slot.previous_version=avai_model_revision.version AND \
+             slot.previous_revision=avai_model_revision.revision\
+             )",
+        )
+        .bind(ModelState::Installed as i32)
+        .bind(ModelState::Ready as i32)
+        .execute(&self.pool)
+        .await
+        .map_err(|error| ModelError::io("reconcile ready model state", error))?;
+        Ok(())
     }
 
     pub async fn remove(&self, identity: &ModelIdentity) -> ModelResult<()> {
@@ -438,6 +569,52 @@ fn decode_model(row: base_db::sqlx::sqlite::SqliteRow) -> ModelResult<InstalledM
             .map_err(|error| ModelError::io("parse model self-tests", error))?,
         state: ModelState::try_from(row.try_get::<i32, _>("state").map_err(decode_error)?)?,
         active_generation: active_generation
+            .map(u64::try_from)
+            .transpose()
+            .map_err(|_| ModelError::new("model_generation_invalid", "negative generation"))?,
+    })
+}
+
+fn decode_slot(row: base_db::sqlx::sqlite::SqliteRow) -> ModelResult<PersistedCapabilitySlot> {
+    let active_generation: i64 = row.try_get("active_generation").map_err(decode_error)?;
+    let previous_model_id: Option<String> =
+        row.try_get("previous_model_id").map_err(decode_error)?;
+    let previous_version: Option<String> = row.try_get("previous_version").map_err(decode_error)?;
+    let previous_revision: Option<String> =
+        row.try_get("previous_revision").map_err(decode_error)?;
+    let previous_generation: Option<i64> =
+        row.try_get("previous_generation").map_err(decode_error)?;
+    let previous_identity = match (previous_model_id, previous_version, previous_revision) {
+        (Some(model_id), Some(version), Some(revision)) => Some(ModelIdentity {
+            model_id,
+            version,
+            revision,
+        }),
+        (None, None, None) => None,
+        _ => {
+            return Err(ModelError::new(
+                "model_slot_invalid",
+                "persisted previous model identity is incomplete",
+            ));
+        }
+    };
+    if previous_identity.is_some() != previous_generation.is_some() {
+        return Err(ModelError::new(
+            "model_slot_invalid",
+            "persisted previous model generation is incomplete",
+        ));
+    }
+    Ok(PersistedCapabilitySlot {
+        capability: row.try_get("capability").map_err(decode_error)?,
+        active_identity: ModelIdentity {
+            model_id: row.try_get("active_model_id").map_err(decode_error)?,
+            version: row.try_get("active_version").map_err(decode_error)?,
+            revision: row.try_get("active_revision").map_err(decode_error)?,
+        },
+        active_generation: u64::try_from(active_generation)
+            .map_err(|_| ModelError::new("model_generation_invalid", "negative generation"))?,
+        previous_identity,
+        previous_generation: previous_generation
             .map(u64::try_from)
             .transpose()
             .map_err(|_| ModelError::new("model_generation_invalid", "negative generation"))?,

--- a/avai/src/model/repository.rs
+++ b/avai/src/model/repository.rs
@@ -1,0 +1,490 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use base_db::{
+    dbx::{DatabasePoolConfig, sqlitex::SqliteConnectionConfig},
+    sqlx::{Row, SqlitePool},
+};
+
+use super::{
+    ModelError, ModelIdentity, ModelResult, VerifiedModelPackage, package::safe_relative_path,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum ModelState {
+    Installed = 1,
+    Ready = 2,
+    Active = 3,
+    Retired = 4,
+    Failed = 5,
+}
+
+impl TryFrom<i32> for ModelState {
+    type Error = ModelError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Installed),
+            2 => Ok(Self::Ready),
+            3 => Ok(Self::Active),
+            4 => Ok(Self::Retired),
+            5 => Ok(Self::Failed),
+            _ => Err(ModelError::new(
+                "model_state_invalid",
+                format!("unknown persisted model state: {value}"),
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InstalledModel {
+    pub identity: ModelIdentity,
+    pub capabilities: Vec<String>,
+    pub runtime: String,
+    pub installed_path: PathBuf,
+    pub manifest_sha256: String,
+    pub resources: super::ResourceHints,
+    pub self_tests: Vec<super::SelfTestCase>,
+    pub state: ModelState,
+    pub active_generation: Option<u64>,
+}
+
+#[derive(Clone)]
+pub struct ModelRepository {
+    pool: SqlitePool,
+    packages_root: Arc<PathBuf>,
+    quarantine_root: Arc<PathBuf>,
+}
+
+impl ModelRepository {
+    pub async fn open(database_path: &Path, model_root: &Path) -> ModelResult<Self> {
+        if let Some(parent) = database_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            create_directory(parent)?;
+        }
+        let packages_root = model_root.join("packages");
+        let quarantine_root = model_root.join("quarantine");
+        create_directory(&packages_root)?;
+        create_directory(&quarantine_root)?;
+        let pool = base_db::dbx::sqlitex::build_sqlite_pool(
+            SqliteConnectionConfig::new(database_path),
+            DatabasePoolConfig {
+                max_size: 4,
+                min_idle: Some(1),
+                ..Default::default()
+            },
+        )
+        .map_err(|error| ModelError::io("configure model database", error))?;
+        base_db::sqlx::query(
+            "CREATE TABLE IF NOT EXISTS avai_model_revision (\
+             model_id TEXT NOT NULL,\
+             version TEXT NOT NULL,\
+             revision TEXT NOT NULL,\
+             capabilities_json TEXT NOT NULL,\
+             runtime TEXT NOT NULL,\
+             installed_path TEXT NOT NULL,\
+             manifest_sha256 TEXT NOT NULL,\
+             memory_mb INTEGER NOT NULL,\
+             vram_mb INTEGER NOT NULL,\
+             max_batch INTEGER NOT NULL,\
+             self_tests_json TEXT NOT NULL,\
+             state INTEGER NOT NULL,\
+             active_generation INTEGER NULL,\
+             installed_at_ms INTEGER NOT NULL,\
+             activated_at_ms INTEGER NULL,\
+             last_error TEXT NULL,\
+             PRIMARY KEY(model_id, version, revision)\
+             )",
+        )
+        .execute(&pool)
+        .await
+        .map_err(|error| ModelError::io("initialize model schema", error))?;
+        Ok(Self {
+            pool,
+            packages_root: Arc::new(packages_root),
+            quarantine_root: Arc::new(quarantine_root),
+        })
+    }
+
+    pub async fn install(
+        &self,
+        package: &VerifiedModelPackage,
+        now_epoch_ms: i64,
+    ) -> ModelResult<InstalledModel> {
+        if let Some(existing) = self.get(&package.manifest.metadata).await? {
+            if existing.manifest_sha256 == package.manifest_sha256 {
+                return Ok(existing);
+            }
+            return Err(ModelError::new(
+                "model_revision_conflict",
+                "immutable model revision already exists with different content",
+            ));
+        }
+        let identity = &package.manifest.metadata;
+        let destination = self
+            .packages_root
+            .join(&identity.model_id)
+            .join(&identity.version)
+            .join(&identity.revision);
+        if destination.exists() {
+            return Err(ModelError::new(
+                "model_revision_conflict",
+                "model revision directory already exists without matching metadata",
+            ));
+        }
+        let staging = destination
+            .parent()
+            .unwrap_or(&self.packages_root)
+            .join(format!(
+                ".{}.installing-{}",
+                identity.revision,
+                std::process::id()
+            ));
+        if staging.exists() {
+            return Err(ModelError::new(
+                "model_install_in_progress",
+                "model revision staging directory already exists",
+            ));
+        }
+        create_directory(&staging)?;
+        let install_result = (|| -> ModelResult<()> {
+            copy_confined_file(
+                &package.root,
+                Path::new("manifest.yaml"),
+                &staging.join("manifest.yaml"),
+            )?;
+            for file in &package.manifest.files {
+                let relative = safe_relative_path(&file.path)?;
+                copy_confined_file(&package.root, &relative, &staging.join(&relative))?;
+            }
+            if let Some(parent) = destination.parent() {
+                create_directory(parent)?;
+            }
+            std::fs::rename(&staging, &destination)
+                .map_err(|error| ModelError::io("commit immutable model revision", error))?;
+            Ok(())
+        })();
+        if let Err(error) = install_result {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(error);
+        }
+        let capabilities_json = base::serde_json::to_string(&package.manifest.capabilities)
+            .map_err(|error| ModelError::io("encode model capabilities", error))?;
+        let self_tests_json = base::serde_json::to_string(&package.manifest.self_test)
+            .map_err(|error| ModelError::io("encode model self-tests", error))?;
+        let result = base_db::sqlx::query(
+            "INSERT INTO avai_model_revision(\
+             model_id,version,revision,capabilities_json,runtime,installed_path,manifest_sha256,\
+             memory_mb,vram_mb,max_batch,self_tests_json,state,installed_at_ms) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        )
+        .bind(&identity.model_id)
+        .bind(&identity.version)
+        .bind(&identity.revision)
+        .bind(capabilities_json)
+        .bind(&package.selected_variant.runtime)
+        .bind(destination.to_string_lossy().as_ref())
+        .bind(&package.manifest_sha256)
+        .bind(
+            i64::try_from(package.manifest.resources.memory_mb).map_err(|_| {
+                ModelError::new(
+                    "model_resource_limit_exceeded",
+                    "memory hint does not fit SQLite",
+                )
+            })?,
+        )
+        .bind(
+            i64::try_from(package.manifest.resources.vram_mb).map_err(|_| {
+                ModelError::new(
+                    "model_resource_limit_exceeded",
+                    "VRAM hint does not fit SQLite",
+                )
+            })?,
+        )
+        .bind(i64::from(package.manifest.resources.max_batch))
+        .bind(self_tests_json)
+        .bind(ModelState::Installed as i32)
+        .bind(now_epoch_ms)
+        .execute(&self.pool)
+        .await;
+        if let Err(error) = result {
+            let _ = std::fs::remove_dir_all(&destination);
+            return Err(ModelError::io("persist installed model", error));
+        }
+        self.get(identity).await?.ok_or_else(|| {
+            ModelError::new(
+                "model_install_failed",
+                "installed model metadata was not readable",
+            )
+        })
+    }
+
+    pub async fn get(&self, identity: &ModelIdentity) -> ModelResult<Option<InstalledModel>> {
+        base_db::sqlx::query(SELECT_MODEL)
+            .bind(&identity.model_id)
+            .bind(&identity.version)
+            .bind(&identity.revision)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|error| ModelError::io("query installed model", error))?
+            .map(decode_model)
+            .transpose()
+    }
+
+    pub async fn list(&self) -> ModelResult<Vec<InstalledModel>> {
+        let rows = base_db::sqlx::query(SELECT_MODELS)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|error| ModelError::io("list installed models", error))?;
+        rows.into_iter().map(decode_model).collect()
+    }
+
+    pub(crate) async fn max_generation(&self) -> ModelResult<u64> {
+        let value: i64 = base_db::sqlx::query_scalar(
+            "SELECT COALESCE(MAX(active_generation), 0) FROM avai_model_revision",
+        )
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|error| ModelError::io("query model generation", error))?;
+        u64::try_from(value)
+            .map_err(|_| ModelError::new("model_generation_invalid", "negative generation"))
+    }
+
+    pub(crate) async fn set_state(
+        &self,
+        identity: &ModelIdentity,
+        state: ModelState,
+        generation: Option<u64>,
+        now_epoch_ms: i64,
+    ) -> ModelResult<()> {
+        let generation = generation
+            .map(i64::try_from)
+            .transpose()
+            .map_err(|_| ModelError::new("model_generation_invalid", "generation is too large"))?;
+        let updated = base_db::sqlx::query(
+            "UPDATE avai_model_revision SET state=?, active_generation=?, activated_at_ms=CASE WHEN ? IS NULL THEN activated_at_ms ELSE ? END, last_error=NULL WHERE model_id=? AND version=? AND revision=?",
+        )
+        .bind(state as i32)
+        .bind(generation)
+        .bind(generation)
+        .bind(now_epoch_ms)
+        .bind(&identity.model_id)
+        .bind(&identity.version)
+        .bind(&identity.revision)
+        .execute(&self.pool)
+        .await
+        .map_err(|error| ModelError::io("update model state", error))?;
+        if updated.rows_affected() != 1 {
+            return Err(ModelError::new(
+                "model_not_found",
+                "installed model does not exist",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn activate(
+        &self,
+        identity: &ModelIdentity,
+        no_longer_active: &[ModelIdentity],
+        generation: u64,
+        now_epoch_ms: i64,
+    ) -> ModelResult<()> {
+        let generation = i64::try_from(generation)
+            .map_err(|_| ModelError::new("model_generation_invalid", "generation is too large"))?;
+        let mut transaction = self
+            .pool
+            .begin()
+            .await
+            .map_err(|error| ModelError::io("begin model activation", error))?;
+        for previous in no_longer_active {
+            base_db::sqlx::query(
+                "UPDATE avai_model_revision SET state=?, active_generation=NULL WHERE model_id=? AND version=? AND revision=?",
+            )
+            .bind(ModelState::Ready as i32)
+            .bind(&previous.model_id)
+            .bind(&previous.version)
+            .bind(&previous.revision)
+            .execute(&mut *transaction)
+            .await
+            .map_err(|error| ModelError::io("persist previous model state", error))?;
+        }
+        let updated = base_db::sqlx::query(
+            "UPDATE avai_model_revision SET state=?, active_generation=?, activated_at_ms=?, last_error=NULL WHERE model_id=? AND version=? AND revision=?",
+        )
+        .bind(ModelState::Active as i32)
+        .bind(generation)
+        .bind(now_epoch_ms)
+        .bind(&identity.model_id)
+        .bind(&identity.version)
+        .bind(&identity.revision)
+        .execute(&mut *transaction)
+        .await
+        .map_err(|error| ModelError::io("persist active model state", error))?;
+        if updated.rows_affected() != 1 {
+            return Err(ModelError::new(
+                "model_not_found",
+                "installed model does not exist",
+            ));
+        }
+        transaction
+            .commit()
+            .await
+            .map_err(|error| ModelError::io("commit model activation", error))
+    }
+
+    pub async fn remove(&self, identity: &ModelIdentity) -> ModelResult<()> {
+        let Some(model) = self.get(identity).await? else {
+            return Ok(());
+        };
+        if matches!(model.state, ModelState::Active | ModelState::Ready) {
+            return Err(ModelError::new(
+                "model_in_use",
+                "active or loaded model revision cannot be removed",
+            ));
+        }
+        let expected_path = self
+            .packages_root
+            .join(&identity.model_id)
+            .join(&identity.version)
+            .join(&identity.revision);
+        if model.installed_path != expected_path {
+            return Err(ModelError::new(
+                "model_path_invalid",
+                "persisted model path does not match its immutable identity",
+            ));
+        }
+        let quarantine = self.quarantine_root.join(format!(
+            ".{}-{}-{}.removing-{}",
+            identity.model_id,
+            identity.version,
+            identity.revision,
+            std::process::id()
+        ));
+        std::fs::rename(&model.installed_path, &quarantine)
+            .map_err(|error| ModelError::io("quarantine model before removal", error))?;
+        let deleted = base_db::sqlx::query(
+            "DELETE FROM avai_model_revision WHERE model_id=? AND version=? AND revision=? AND state NOT IN (?,?)",
+        )
+        .bind(&identity.model_id)
+        .bind(&identity.version)
+        .bind(&identity.revision)
+        .bind(ModelState::Active as i32)
+        .bind(ModelState::Ready as i32)
+        .execute(&self.pool)
+        .await;
+        let deleted = match deleted {
+            Ok(deleted) => deleted,
+            Err(error) => {
+                let _ = std::fs::rename(&quarantine, &model.installed_path);
+                return Err(ModelError::io("delete model metadata", error));
+            }
+        };
+        if deleted.rows_affected() != 1 {
+            let _ = std::fs::rename(&quarantine, &model.installed_path);
+            return Err(ModelError::new(
+                "model_in_use",
+                "model state changed during removal",
+            ));
+        }
+        std::fs::remove_dir_all(&quarantine)
+            .map_err(|error| ModelError::io("remove quarantined model files", error))?;
+        Ok(())
+    }
+
+    pub async fn close(&self) {
+        self.pool.close().await;
+    }
+}
+
+const SELECT_MODEL: &str = "SELECT model_id,version,revision,capabilities_json,runtime,installed_path,manifest_sha256,memory_mb,vram_mb,max_batch,self_tests_json,state,active_generation FROM avai_model_revision WHERE model_id=? AND version=? AND revision=?";
+const SELECT_MODELS: &str = "SELECT model_id,version,revision,capabilities_json,runtime,installed_path,manifest_sha256,memory_mb,vram_mb,max_batch,self_tests_json,state,active_generation FROM avai_model_revision ORDER BY model_id,version,revision";
+
+fn decode_model(row: base_db::sqlx::sqlite::SqliteRow) -> ModelResult<InstalledModel> {
+    let capabilities_json: String = row
+        .try_get("capabilities_json")
+        .map_err(|error| ModelError::io("decode model capabilities", error))?;
+    let self_tests_json: String = row
+        .try_get("self_tests_json")
+        .map_err(|error| ModelError::io("decode model self-tests", error))?;
+    let memory_mb: i64 = row.try_get("memory_mb").map_err(decode_error)?;
+    let vram_mb: i64 = row.try_get("vram_mb").map_err(decode_error)?;
+    let max_batch: i64 = row.try_get("max_batch").map_err(decode_error)?;
+    let active_generation: Option<i64> = row.try_get("active_generation").map_err(decode_error)?;
+    Ok(InstalledModel {
+        identity: ModelIdentity {
+            model_id: row.try_get("model_id").map_err(decode_error)?,
+            version: row.try_get("version").map_err(decode_error)?,
+            revision: row.try_get("revision").map_err(decode_error)?,
+        },
+        capabilities: base::serde_json::from_str(&capabilities_json)
+            .map_err(|error| ModelError::io("parse model capabilities", error))?,
+        runtime: row.try_get("runtime").map_err(decode_error)?,
+        installed_path: PathBuf::from(
+            row.try_get::<String, _>("installed_path")
+                .map_err(decode_error)?,
+        ),
+        manifest_sha256: row.try_get("manifest_sha256").map_err(decode_error)?,
+        resources: super::ResourceHints {
+            memory_mb: u64::try_from(memory_mb).map_err(|_| invalid_resource())?,
+            vram_mb: u64::try_from(vram_mb).map_err(|_| invalid_resource())?,
+            max_batch: u32::try_from(max_batch).map_err(|_| invalid_resource())?,
+        },
+        self_tests: base::serde_json::from_str(&self_tests_json)
+            .map_err(|error| ModelError::io("parse model self-tests", error))?,
+        state: ModelState::try_from(row.try_get::<i32, _>("state").map_err(decode_error)?)?,
+        active_generation: active_generation
+            .map(u64::try_from)
+            .transpose()
+            .map_err(|_| ModelError::new("model_generation_invalid", "negative generation"))?,
+    })
+}
+
+fn decode_error(error: impl std::fmt::Display) -> ModelError {
+    ModelError::io("decode installed model", error)
+}
+
+fn invalid_resource() -> ModelError {
+    ModelError::new(
+        "model_resource_invalid",
+        "persisted resource hint is invalid",
+    )
+}
+
+fn create_directory(path: &Path) -> ModelResult<()> {
+    std::fs::create_dir_all(path).map_err(|error| ModelError::io("create model directory", error))
+}
+
+fn copy_confined_file(root: &Path, relative: &Path, destination: &Path) -> ModelResult<()> {
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|error| ModelError::io("resolve model package root", error))?;
+    let source = root.join(relative);
+    let canonical_source = source
+        .canonicalize()
+        .map_err(|error| ModelError::io("resolve model source file", error))?;
+    if !canonical_source.starts_with(&canonical_root) {
+        return Err(ModelError::new(
+            "model_path_invalid",
+            "model source resolves outside the package root",
+        ));
+    }
+    let metadata = std::fs::symlink_metadata(&source)
+        .map_err(|error| ModelError::io("inspect model source file", error))?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(ModelError::new(
+            "invalid_model_package",
+            format!("model source is not a regular file: {}", source.display()),
+        ));
+    }
+    if let Some(parent) = destination.parent() {
+        create_directory(parent)?;
+    }
+    std::fs::copy(&canonical_source, destination)
+        .map_err(|error| ModelError::io("copy model package file", error))?;
+    Ok(())
+}

--- a/avai/src/model/runtime.rs
+++ b/avai/src/model/runtime.rs
@@ -1,0 +1,189 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use base::tokio::sync::Notify;
+
+use super::{InstalledModel, ModelError, ModelIdentity, ModelResult, SelfTestCase};
+
+pub type RuntimeFuture<'a, T> = Pin<Box<dyn Future<Output = ModelResult<T>> + Send + 'a>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeDescriptor {
+    pub runtime: String,
+    pub version: String,
+}
+
+pub trait RuntimeProvider: Send + Sync {
+    fn descriptor(&self) -> RuntimeDescriptor;
+
+    fn preload<'a>(
+        &'a self,
+        model: &'a InstalledModel,
+    ) -> RuntimeFuture<'a, Arc<dyn ModelInstance>>;
+}
+
+pub trait ModelInstance: Send + Sync {
+    fn identity(&self) -> &ModelIdentity;
+    fn runtime(&self) -> &str;
+    fn capabilities(&self) -> &[String];
+
+    fn self_test<'a>(&'a self, cases: &'a [SelfTestCase]) -> RuntimeFuture<'a, ()>;
+
+    fn health<'a>(&'a self) -> RuntimeFuture<'a, ()>;
+
+    fn infer<'a>(&'a self, input: Vec<u8>) -> RuntimeFuture<'a, InferenceResult>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceResult {
+    pub output: Vec<u8>,
+    pub actual_model: gmv_protocol::avai::v1::ModelRef,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FakeRuntimeBehavior {
+    pub fail_preload: bool,
+    pub fail_preload_model: Option<String>,
+    pub fail_self_test: bool,
+    pub fail_self_test_model: Option<String>,
+    pub fail_health: bool,
+    pub block_inference: bool,
+}
+
+#[derive(Clone)]
+pub struct FakeRuntimeProvider {
+    descriptor: RuntimeDescriptor,
+    behavior: FakeRuntimeBehavior,
+    started: Arc<AtomicUsize>,
+    release: Arc<Notify>,
+}
+
+impl FakeRuntimeProvider {
+    pub fn new(runtime: impl Into<String>, behavior: FakeRuntimeBehavior) -> Self {
+        Self {
+            descriptor: RuntimeDescriptor {
+                runtime: runtime.into(),
+                version: "fake-v1".to_string(),
+            },
+            behavior,
+            started: Arc::new(AtomicUsize::new(0)),
+            release: Arc::new(Notify::new()),
+        }
+    }
+
+    pub fn started_inferences(&self) -> usize {
+        self.started.load(Ordering::Acquire)
+    }
+
+    pub fn release_inferences(&self) {
+        self.release.notify_waiters();
+    }
+}
+
+impl RuntimeProvider for FakeRuntimeProvider {
+    fn descriptor(&self) -> RuntimeDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn preload<'a>(
+        &'a self,
+        model: &'a InstalledModel,
+    ) -> RuntimeFuture<'a, Arc<dyn ModelInstance>> {
+        Box::pin(async move {
+            if self.behavior.fail_preload
+                || self
+                    .behavior
+                    .fail_preload_model
+                    .as_ref()
+                    .is_some_and(|model_id| model_id == &model.identity.model_id)
+            {
+                return Err(ModelError::new(
+                    "model_preload_failed",
+                    "fake runtime preload failure",
+                ));
+            }
+            Ok(Arc::new(FakeModelInstance {
+                identity: model.identity.clone(),
+                runtime: model.runtime.clone(),
+                capabilities: model.capabilities.clone(),
+                behavior: self.behavior.clone(),
+                started: self.started.clone(),
+                release: self.release.clone(),
+            }) as Arc<dyn ModelInstance>)
+        })
+    }
+}
+
+struct FakeModelInstance {
+    identity: ModelIdentity,
+    runtime: String,
+    capabilities: Vec<String>,
+    behavior: FakeRuntimeBehavior,
+    started: Arc<AtomicUsize>,
+    release: Arc<Notify>,
+}
+
+impl ModelInstance for FakeModelInstance {
+    fn identity(&self) -> &ModelIdentity {
+        &self.identity
+    }
+
+    fn runtime(&self) -> &str {
+        &self.runtime
+    }
+
+    fn capabilities(&self) -> &[String] {
+        &self.capabilities
+    }
+
+    fn self_test<'a>(&'a self, _cases: &'a [SelfTestCase]) -> RuntimeFuture<'a, ()> {
+        Box::pin(async move {
+            if self.behavior.fail_self_test
+                || self
+                    .behavior
+                    .fail_self_test_model
+                    .as_ref()
+                    .is_some_and(|model_id| model_id == &self.identity.model_id)
+            {
+                Err(ModelError::new(
+                    "model_self_test_failed",
+                    "fake runtime self-test failure",
+                ))
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    fn health<'a>(&'a self) -> RuntimeFuture<'a, ()> {
+        Box::pin(async move {
+            if self.behavior.fail_health {
+                Err(ModelError::new(
+                    "model_health_failed",
+                    "fake runtime health failure",
+                ))
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    fn infer<'a>(&'a self, input: Vec<u8>) -> RuntimeFuture<'a, InferenceResult> {
+        Box::pin(async move {
+            self.started.fetch_add(1, Ordering::AcqRel);
+            if self.behavior.block_inference {
+                self.release.notified().await;
+            }
+            Ok(InferenceResult {
+                output: input,
+                actual_model: self.identity.actual_model(self.runtime.clone()),
+            })
+        })
+    }
+}

--- a/avai/src/model/runtime.rs
+++ b/avai/src/model/runtime.rs
@@ -1,9 +1,10 @@
 use std::{
+    collections::{HashMap, HashSet},
     future::Future,
     pin::Pin,
     sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex, RwLock,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -62,6 +63,11 @@ pub struct FakeRuntimeProvider {
     behavior: FakeRuntimeBehavior,
     started: Arc<AtomicUsize>,
     release: Arc<Notify>,
+    unhealthy_models: Arc<RwLock<HashSet<String>>>,
+    pause_health: Arc<AtomicBool>,
+    health_started: Arc<AtomicUsize>,
+    health_release: Arc<Notify>,
+    dropped: Arc<Mutex<HashMap<String, usize>>>,
 }
 
 impl FakeRuntimeProvider {
@@ -74,6 +80,11 @@ impl FakeRuntimeProvider {
             behavior,
             started: Arc::new(AtomicUsize::new(0)),
             release: Arc::new(Notify::new()),
+            unhealthy_models: Arc::new(RwLock::new(HashSet::new())),
+            pause_health: Arc::new(AtomicBool::new(false)),
+            health_started: Arc::new(AtomicUsize::new(0)),
+            health_release: Arc::new(Notify::new()),
+            dropped: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -83,6 +94,40 @@ impl FakeRuntimeProvider {
 
     pub fn release_inferences(&self) {
         self.release.notify_waiters();
+    }
+
+    pub fn set_model_unhealthy(&self, model_id: &str, unhealthy: bool) {
+        let mut models = self
+            .unhealthy_models
+            .write()
+            .expect("health state poisoned");
+        if unhealthy {
+            models.insert(model_id.to_string());
+        } else {
+            models.remove(model_id);
+        }
+    }
+
+    pub fn pause_health_checks(&self) {
+        self.pause_health.store(true, Ordering::Release);
+    }
+
+    pub fn started_health_checks(&self) -> usize {
+        self.health_started.load(Ordering::Acquire)
+    }
+
+    pub fn release_health_checks(&self) {
+        self.pause_health.store(false, Ordering::Release);
+        self.health_release.notify_waiters();
+    }
+
+    pub fn dropped_instances(&self, model_id: &str) -> usize {
+        self.dropped
+            .lock()
+            .expect("drop state poisoned")
+            .get(model_id)
+            .copied()
+            .unwrap_or_default()
     }
 }
 
@@ -115,6 +160,11 @@ impl RuntimeProvider for FakeRuntimeProvider {
                 behavior: self.behavior.clone(),
                 started: self.started.clone(),
                 release: self.release.clone(),
+                unhealthy_models: self.unhealthy_models.clone(),
+                pause_health: self.pause_health.clone(),
+                health_started: self.health_started.clone(),
+                health_release: self.health_release.clone(),
+                dropped: self.dropped.clone(),
             }) as Arc<dyn ModelInstance>)
         })
     }
@@ -127,6 +177,18 @@ struct FakeModelInstance {
     behavior: FakeRuntimeBehavior,
     started: Arc<AtomicUsize>,
     release: Arc<Notify>,
+    unhealthy_models: Arc<RwLock<HashSet<String>>>,
+    pause_health: Arc<AtomicBool>,
+    health_started: Arc<AtomicUsize>,
+    health_release: Arc<Notify>,
+    dropped: Arc<Mutex<HashMap<String, usize>>>,
+}
+
+impl Drop for FakeModelInstance {
+    fn drop(&mut self) {
+        let mut dropped = self.dropped.lock().expect("drop state poisoned");
+        *dropped.entry(self.identity.model_id.clone()).or_default() += 1;
+    }
 }
 
 impl ModelInstance for FakeModelInstance {
@@ -163,7 +225,18 @@ impl ModelInstance for FakeModelInstance {
 
     fn health<'a>(&'a self) -> RuntimeFuture<'a, ()> {
         Box::pin(async move {
-            if self.behavior.fail_health {
+            let released = self.health_release.notified();
+            self.health_started.fetch_add(1, Ordering::AcqRel);
+            if self.pause_health.load(Ordering::Acquire) {
+                released.await;
+            }
+            if self.behavior.fail_health
+                || self
+                    .unhealthy_models
+                    .read()
+                    .expect("health state poisoned")
+                    .contains(&self.identity.model_id)
+            {
                 Err(ModelError::new(
                     "model_health_failed",
                     "fake runtime health failure",

--- a/avai/tests/model_runtime.rs
+++ b/avai/tests/model_runtime.rs
@@ -8,9 +8,9 @@ use std::{
 };
 
 use avai::model::{
-    FakeRuntimeBehavior, FakeRuntimeProvider, ModelIdentity, ModelManager, ModelManagerConfig,
-    ModelPackageManifest, ModelRepository, ModelState, PackagePolicy, RuntimeProvider,
-    model_package_signing_payload, verify_package,
+    FakeRuntimeBehavior, FakeRuntimeProvider, HealthReconcile, ModelIdentity, ModelManager,
+    ModelManagerConfig, ModelPackageManifest, ModelRepository, ModelState, PackagePolicy,
+    RuntimeProvider, model_package_signing_payload, verify_package,
 };
 use base::{
     base64::Engine,
@@ -257,6 +257,29 @@ async fn repository_installs_immutable_revision_and_persists_state() {
 }
 
 #[tokio::test]
+async fn install_rejects_package_mutated_after_verification() {
+    let root = TestRoot::new("install-toctou");
+    let source = root.path().join("source");
+    std::fs::create_dir_all(&source).unwrap();
+    write_package(&source, "model-a", "1", "rev-a");
+    let package = verify_package(&source, &policy()).unwrap();
+    std::fs::write(source.join("model/model.bin"), b"fake-modex").unwrap();
+    let repository =
+        ModelRepository::open(&root.path().join("avai.db"), &root.path().join("models"))
+            .await
+            .unwrap();
+    let model_a = identity("model-a", "1", "rev-a");
+
+    assert_eq!(
+        repository.install(&package, 1).await.unwrap_err().code,
+        "model_file_hash_mismatch"
+    );
+    assert!(repository.get(&model_a).await.unwrap().is_none());
+    assert!(!root.path().join("models/packages/model-a/1/rev-a").exists());
+    repository.close().await;
+}
+
+#[tokio::test]
 async fn atomic_switch_keeps_in_flight_tasks_on_captured_generation() {
     let root = TestRoot::new("atomic-switch");
     let repository = repository_with_models(&root).await;
@@ -295,23 +318,272 @@ async fn atomic_switch_keeps_in_flight_tasks_on_captured_generation() {
     assert!(generation_b > generation_a);
     let new_task = manager.capture(CAPABILITY).await.unwrap();
     assert_eq!(new_task.identity(), &model_b);
+    assert_eq!(
+        manager
+            .retire_previous(CAPABILITY, 14)
+            .await
+            .unwrap_err()
+            .code,
+        "model_in_use"
+    );
+    assert_eq!(fake.dropped_instances("model-a"), 0);
     fake.release_inferences();
     for task in tasks {
         let result = task.await.unwrap();
         assert_eq!(result.actual_model.model_id, "model-a");
     }
     drop(new_task);
+    assert_eq!(fake.dropped_instances("model-a"), 0);
     assert_eq!(
-        manager.retire_previous(CAPABILITY, 14).await.unwrap(),
+        manager.retire_previous(CAPABILITY, 15).await.unwrap(),
         Some(model_a.clone())
     );
-    manager.unload(&model_a, 15).await.unwrap();
+    manager.unload(&model_a, 16).await.unwrap();
+    assert_eq!(fake.dropped_instances("model-a"), 1);
+    manager.unload(&model_a, 17).await.unwrap();
+    assert_eq!(fake.dropped_instances("model-a"), 1);
     assert!(
         manager
             .status()
             .await
             .iter()
             .all(|status| status.identity != model_a)
+    );
+    repository.close().await;
+}
+
+#[tokio::test]
+async fn activate_and_unload_share_one_lifecycle_boundary() {
+    let root = TestRoot::new("activate-unload-race");
+    let repository = repository_with_models(&root).await;
+    let fake = FakeRuntimeProvider::new("fake", FakeRuntimeBehavior::default());
+    let manager = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(fake.clone())],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    let model_a = identity("model-a", "1", "rev-a");
+    let model_b = identity("model-b", "2", "rev-b");
+    manager.preload(&model_a, 10).await.unwrap();
+    manager.preload(&model_b, 11).await.unwrap();
+    manager.activate(&model_a, 12).await.unwrap();
+
+    let health_before = fake.started_health_checks();
+    fake.pause_health_checks();
+    let activate_manager = manager.clone();
+    let activate_model = model_b.clone();
+    let activate =
+        tokio::spawn(async move { activate_manager.activate(&activate_model, 13).await });
+    while fake.started_health_checks() == health_before {
+        tokio::task::yield_now().await;
+    }
+    let unload_manager = manager.clone();
+    let unload_model = model_b.clone();
+    let unload = tokio::spawn(async move { unload_manager.unload(&unload_model, 14).await });
+    tokio::task::yield_now().await;
+    assert!(!unload.is_finished());
+    fake.release_health_checks();
+
+    assert!(activate.await.unwrap().is_ok());
+    assert_eq!(unload.await.unwrap().unwrap_err().code, "model_in_use");
+    assert_eq!(
+        manager.capture(CAPABILITY).await.unwrap().identity(),
+        &model_b
+    );
+    assert_eq!(
+        repository.get(&model_b).await.unwrap().unwrap().state,
+        ModelState::Active
+    );
+    assert!(
+        manager
+            .status()
+            .await
+            .iter()
+            .any(|status| status.identity == model_b)
+    );
+    repository.close().await;
+}
+
+#[tokio::test]
+async fn restart_reconciles_ready_and_restores_previous_for_rollback() {
+    let root = TestRoot::new("restart-slots");
+    let repository = repository_with_models(&root).await;
+    let model_a = identity("model-a", "1", "rev-a");
+    let model_b = identity("model-b", "2", "rev-b");
+
+    let ready_manager = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(FakeRuntimeProvider::new(
+            "fake",
+            FakeRuntimeBehavior::default(),
+        ))],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    ready_manager.preload(&model_a, 20).await.unwrap();
+    drop(ready_manager);
+    let restarted = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(FakeRuntimeProvider::new(
+            "fake",
+            FakeRuntimeBehavior::default(),
+        ))],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    assert!(restarted.status().await.is_empty());
+    assert_eq!(
+        repository.get(&model_a).await.unwrap().unwrap().state,
+        ModelState::Installed
+    );
+
+    restarted.preload(&model_a, 21).await.unwrap();
+    restarted.preload(&model_b, 22).await.unwrap();
+    restarted.activate(&model_a, 23).await.unwrap();
+    restarted.activate(&model_b, 24).await.unwrap();
+    drop(restarted);
+    let restarted = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(FakeRuntimeProvider::new(
+            "fake",
+            FakeRuntimeBehavior::default(),
+        ))],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        restarted.capture(CAPABILITY).await.unwrap().identity(),
+        &model_b
+    );
+    restarted.rollback(CAPABILITY, 25).await.unwrap();
+    assert_eq!(
+        restarted.capture(CAPABILITY).await.unwrap().identity(),
+        &model_a
+    );
+    repository.close().await;
+}
+
+#[tokio::test]
+async fn transient_lifecycle_states_are_never_durably_exposed() {
+    let root = TestRoot::new("stable-states-only");
+    let repository = repository_with_models(&root).await;
+    let fake = FakeRuntimeProvider::new("fake", FakeRuntimeBehavior::default());
+    let manager = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(fake.clone())],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    let model_a = identity("model-a", "1", "rev-a");
+    let model_b = identity("model-b", "2", "rev-b");
+
+    let health_before = fake.started_health_checks();
+    fake.pause_health_checks();
+    let preload_manager = manager.clone();
+    let preload_model = model_a.clone();
+    let preload = tokio::spawn(async move { preload_manager.preload(&preload_model, 30).await });
+    while fake.started_health_checks() == health_before {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        repository.get(&model_a).await.unwrap().unwrap().state,
+        ModelState::Installed
+    );
+    fake.release_health_checks();
+    preload.await.unwrap().unwrap();
+
+    manager.preload(&model_b, 31).await.unwrap();
+    manager.activate(&model_a, 32).await.unwrap();
+    let held = manager.capture(CAPABILITY).await.unwrap();
+    manager.activate(&model_b, 33).await.unwrap();
+    assert_eq!(
+        manager
+            .retire_previous(CAPABILITY, 34)
+            .await
+            .unwrap_err()
+            .code,
+        "model_in_use"
+    );
+    drop(held);
+    drop(manager);
+    let restarted = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(FakeRuntimeProvider::new(
+            "fake",
+            FakeRuntimeBehavior::default(),
+        ))],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    restarted.rollback(CAPABILITY, 35).await.unwrap();
+    assert_eq!(
+        restarted.capture(CAPABILITY).await.unwrap().identity(),
+        &model_a
+    );
+    repository.close().await;
+}
+
+#[tokio::test]
+async fn unhealthy_active_model_rolls_back_to_healthy_previous() {
+    let root = TestRoot::new("health-rollback");
+    let repository = repository_with_models(&root).await;
+    let fake = FakeRuntimeProvider::new("fake", FakeRuntimeBehavior::default());
+    let manager = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(fake.clone())],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    let model_a = identity("model-a", "1", "rev-a");
+    let model_b = identity("model-b", "2", "rev-b");
+    manager.preload(&model_a, 40).await.unwrap();
+    manager.preload(&model_b, 41).await.unwrap();
+    manager.activate(&model_a, 42).await.unwrap();
+    manager.activate(&model_b, 43).await.unwrap();
+    fake.set_model_unhealthy("model-b", true);
+
+    let result = manager
+        .reconcile_active_health(CAPABILITY, 44)
+        .await
+        .unwrap();
+    assert!(matches!(
+        result,
+        HealthReconcile::RolledBack {
+            failed,
+            restored,
+            ..
+        } if failed == model_b && restored == model_a
+    ));
+    assert_eq!(
+        manager.capture(CAPABILITY).await.unwrap().identity(),
+        &model_a
+    );
+    assert_eq!(
+        repository.get(&model_b).await.unwrap().unwrap().state,
+        ModelState::Failed
+    );
+    drop(manager);
+    let restarted = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(FakeRuntimeProvider::new(
+            "fake",
+            FakeRuntimeBehavior::default(),
+        ))],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        restarted.capture(CAPABILITY).await.unwrap().identity(),
+        &model_a
     );
     repository.close().await;
 }

--- a/avai/tests/model_runtime.rs
+++ b/avai/tests/model_runtime.rs
@@ -1,0 +1,424 @@
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
+use avai::model::{
+    FakeRuntimeBehavior, FakeRuntimeProvider, ModelIdentity, ModelManager, ModelManagerConfig,
+    ModelPackageManifest, ModelRepository, ModelState, PackagePolicy, RuntimeProvider,
+    model_package_signing_payload, verify_package,
+};
+use base::{
+    base64::Engine,
+    sha2::{Digest, Sha256},
+};
+use ed25519_dalek::{Signer, SigningKey};
+
+static NEXT_TEMP: AtomicUsize = AtomicUsize::new(1);
+const CAPABILITY: &str = "vehicle.detect";
+
+struct TestRoot(PathBuf);
+
+impl TestRoot {
+    fn new(name: &str) -> Self {
+        let id = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "avai-model-runtime-{name}-{}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TestRoot {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn write_package(root: &Path, model_id: &str, version: &str, revision: &str) {
+    let files = [
+        ("model/model.bin", b"fake-model".as_slice()),
+        (
+            "schema/result.schema.json",
+            br#"{"type":"object"}"#.as_slice(),
+        ),
+        ("tests/input.bin", b"input".as_slice()),
+        ("tests/expected.json", br#"{"ok":true}"#.as_slice()),
+    ];
+    for (relative, bytes) in files {
+        let path = root.join(relative);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, bytes).unwrap();
+    }
+    let file_yaml = files
+        .iter()
+        .map(|(path, bytes)| {
+            format!(
+                "  - path: {path}\n    sha256: {:x}\n    size: {}",
+                Sha256::digest(bytes),
+                bytes.len()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let unsigned_manifest = format!(
+        "api_version: gmv.ai/v1\nkind: ModelPlugin\nmetadata:\n  model_id: {model_id}\n  version: {version}\n  revision: {revision}\ncapabilities:\n  - {CAPABILITY}\nresult_schema:\n  name: gmv.vision.observation\n  version: 1\n  path: schema/result.schema.json\nvariants:\n  - runtime: fake\n    architecture: {}\n    accelerator: cpu\n    artifact: model/model.bin\nresources:\n  memory_mb: 64\n  vram_mb: 0\n  max_batch: 4\nlicense:\n  spdx: Apache-2.0\n  commercial_use: true\n  redistribution: allowed\n  license_ref: \"\"\nself_test:\n  - input: tests/input.bin\n    expected: tests/expected.json\nfiles:\n{file_yaml}\nsigning:\n  key_id: test-key\n  signature: \"\"\n",
+        std::env::consts::ARCH
+    );
+    let manifest = sign_manifest(&unsigned_manifest);
+    std::fs::write(root.join("manifest.yaml"), manifest).unwrap();
+}
+
+fn sign_manifest(unsigned_manifest: &str) -> String {
+    let parsed: ModelPackageManifest = base::serde_yaml::from_str(unsigned_manifest).unwrap();
+    let signature =
+        SigningKey::from_bytes(&[7; 32]).sign(&model_package_signing_payload(&parsed).unwrap());
+    unsigned_manifest.replace(
+        "signature: \"\"",
+        &format!(
+            "signature: {}",
+            base::base64::engine::general_purpose::STANDARD.encode(signature.to_bytes())
+        ),
+    )
+}
+
+fn resign_manifest(manifest: &str) -> String {
+    let signature_line = manifest
+        .lines()
+        .find(|line| line.trim_start().starts_with("signature:"))
+        .unwrap();
+    sign_manifest(&manifest.replace(signature_line, "  signature: \"\""))
+}
+
+fn policy() -> PackagePolicy {
+    PackagePolicy {
+        available_runtimes: HashSet::from(["fake".to_string()]),
+        allowed_result_schemas: HashSet::from([("gmv.vision.observation".to_string(), 1)]),
+        approved_spdx: HashSet::from(["Apache-2.0".to_string()]),
+        trusted_signing_keys: HashMap::from([(
+            "test-key".to_string(),
+            SigningKey::from_bytes(&[7; 32])
+                .verifying_key()
+                .to_bytes()
+                .to_vec(),
+        )]),
+        max_memory_mb: 128,
+        max_vram_mb: 0,
+        ..PackagePolicy::default()
+    }
+}
+
+fn identity(model_id: &str, version: &str, revision: &str) -> ModelIdentity {
+    ModelIdentity {
+        model_id: model_id.to_string(),
+        version: version.to_string(),
+        revision: revision.to_string(),
+    }
+}
+
+async fn repository_with_models(root: &TestRoot) -> ModelRepository {
+    let repository =
+        ModelRepository::open(&root.path().join("avai.db"), &root.path().join("models"))
+            .await
+            .unwrap();
+    for (model_id, version, revision) in [("model-a", "1", "rev-a"), ("model-b", "2", "rev-b")] {
+        let package_root = root.path().join(format!("source-{revision}"));
+        std::fs::create_dir_all(&package_root).unwrap();
+        write_package(&package_root, model_id, version, revision);
+        let package = verify_package(&package_root, &policy()).unwrap();
+        repository.install(&package, 1).await.unwrap();
+    }
+    repository
+}
+
+#[test]
+fn package_verifier_rejects_untrusted_and_malformed_inputs() {
+    let root = TestRoot::new("bad-package");
+    write_package(root.path(), "model-a", "1", "rev-a");
+    assert!(verify_package(root.path(), &policy()).is_ok());
+
+    let model_path = root.path().join("model/model.bin");
+    std::fs::write(&model_path, b"fake-modex").unwrap();
+    assert_eq!(
+        verify_package(root.path(), &policy()).unwrap_err().code,
+        "model_file_hash_mismatch"
+    );
+    std::fs::write(&model_path, b"fake-model").unwrap();
+
+    let manifest_path = root.path().join("manifest.yaml");
+    let valid = std::fs::read_to_string(&manifest_path).unwrap();
+    std::fs::write(&manifest_path, valid.replace("gmv.ai/v1", "gmv.ai/v999")).unwrap();
+    assert_eq!(
+        verify_package(root.path(), &policy()).unwrap_err().code,
+        "unsupported_model_schema"
+    );
+    std::fs::write(&manifest_path, &valid).unwrap();
+
+    let expected_path = root.path().join("tests/expected.json");
+    std::fs::remove_file(&expected_path).unwrap();
+    assert!(verify_package(root.path(), &policy()).is_err());
+    std::fs::write(&expected_path, br#"{"ok":true}"#).unwrap();
+
+    let schema_path = root.path().join("schema/result.schema.json");
+    let valid_schema = std::fs::read(&schema_path).unwrap();
+    let invalid_schema = b"not valid json!!!";
+    assert_eq!(valid_schema.len(), invalid_schema.len());
+    std::fs::write(&schema_path, invalid_schema).unwrap();
+    let schema_manifest = valid.replace(
+        &format!("{:x}", Sha256::digest(&valid_schema)),
+        &format!("{:x}", Sha256::digest(invalid_schema)),
+    );
+    std::fs::write(&manifest_path, resign_manifest(&schema_manifest)).unwrap();
+    assert_eq!(
+        verify_package(root.path(), &policy()).unwrap_err().code,
+        "invalid_result_schema"
+    );
+    std::fs::write(&schema_path, valid_schema).unwrap();
+    std::fs::write(&manifest_path, &valid).unwrap();
+
+    std::fs::write(
+        &manifest_path,
+        valid.replace("signature: ", "signature: AA"),
+    )
+    .unwrap();
+    assert_eq!(
+        verify_package(root.path(), &policy()).unwrap_err().code,
+        "model_signature_invalid"
+    );
+    std::fs::write(&manifest_path, &valid).unwrap();
+
+    let mut incompatible = policy();
+    incompatible.architecture = "incompatible-arch".to_string();
+    assert_eq!(
+        verify_package(root.path(), &incompatible).unwrap_err().code,
+        "model_runtime_incompatible"
+    );
+    let mut no_license = policy();
+    no_license.approved_spdx.clear();
+    assert_eq!(
+        verify_package(root.path(), &no_license).unwrap_err().code,
+        "model_license_unavailable"
+    );
+    let mut too_small = policy();
+    too_small.max_memory_mb = 32;
+    assert_eq!(
+        verify_package(root.path(), &too_small).unwrap_err().code,
+        "model_resource_limit_exceeded"
+    );
+
+    let unsafe_manifest = valid.replace("model/model.bin", "../model.bin");
+    std::fs::write(&manifest_path, resign_manifest(&unsafe_manifest)).unwrap();
+    assert_eq!(
+        verify_package(root.path(), &policy()).unwrap_err().code,
+        "model_path_invalid"
+    );
+}
+
+#[tokio::test]
+async fn repository_installs_immutable_revision_and_persists_state() {
+    let root = TestRoot::new("repository");
+    let repository = repository_with_models(&root).await;
+    let model_a = identity("model-a", "1", "rev-a");
+    let installed = repository.get(&model_a).await.unwrap().unwrap();
+    assert_eq!(installed.state, ModelState::Installed);
+    assert!(installed.installed_path.join("model/model.bin").is_file());
+
+    let source = root.path().join("source-rev-a");
+    let package = verify_package(&source, &policy()).unwrap();
+    let repeated = repository.install(&package, 2).await.unwrap();
+    assert_eq!(repeated.installed_path, installed.installed_path);
+    let model_b = identity("model-b", "2", "rev-b");
+    let model_b_path = repository
+        .get(&model_b)
+        .await
+        .unwrap()
+        .unwrap()
+        .installed_path;
+    repository.remove(&model_b).await.unwrap();
+    assert!(!model_b_path.exists());
+    assert!(repository.get(&model_b).await.unwrap().is_none());
+    repository.close().await;
+
+    let reopened = ModelRepository::open(&root.path().join("avai.db"), &root.path().join("models"))
+        .await
+        .unwrap();
+    assert_eq!(reopened.list().await.unwrap().len(), 1);
+    reopened.close().await;
+}
+
+#[tokio::test]
+async fn atomic_switch_keeps_in_flight_tasks_on_captured_generation() {
+    let root = TestRoot::new("atomic-switch");
+    let repository = repository_with_models(&root).await;
+    let fake = FakeRuntimeProvider::new(
+        "fake",
+        FakeRuntimeBehavior {
+            block_inference: true,
+            ..FakeRuntimeBehavior::default()
+        },
+    );
+    let providers: Vec<Arc<dyn RuntimeProvider>> = vec![Arc::new(fake.clone())];
+    let manager = ModelManager::open(repository.clone(), providers, ModelManagerConfig::default())
+        .await
+        .unwrap();
+    let model_a = identity("model-a", "1", "rev-a");
+    let model_b = identity("model-b", "2", "rev-b");
+    manager.preload(&model_a, 10).await.unwrap();
+    manager.preload(&model_b, 11).await.unwrap();
+    let generation_a = manager.activate(&model_a, 12).await.unwrap();
+
+    let mut tasks = Vec::new();
+    for _ in 0..100 {
+        let active = manager.capture(CAPABILITY).await.unwrap();
+        tasks.push(tokio::spawn(
+            async move { active.infer(vec![1]).await.unwrap() },
+        ));
+    }
+    for _ in 0..100 {
+        if fake.started_inferences() == 100 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(fake.started_inferences(), 100);
+    let generation_b = manager.activate(&model_b, 13).await.unwrap();
+    assert!(generation_b > generation_a);
+    let new_task = manager.capture(CAPABILITY).await.unwrap();
+    assert_eq!(new_task.identity(), &model_b);
+    fake.release_inferences();
+    for task in tasks {
+        let result = task.await.unwrap();
+        assert_eq!(result.actual_model.model_id, "model-a");
+    }
+    drop(new_task);
+    assert_eq!(
+        manager.retire_previous(CAPABILITY, 14).await.unwrap(),
+        Some(model_a.clone())
+    );
+    manager.unload(&model_a, 15).await.unwrap();
+    assert!(
+        manager
+            .status()
+            .await
+            .iter()
+            .all(|status| status.identity != model_a)
+    );
+    repository.close().await;
+}
+
+#[tokio::test]
+async fn failed_candidate_does_not_replace_active_and_rollback_is_explicit() {
+    let root = TestRoot::new("failure-rollback");
+    let repository = repository_with_models(&root).await;
+    let good: Vec<Arc<dyn RuntimeProvider>> = vec![Arc::new(FakeRuntimeProvider::new(
+        "fake",
+        FakeRuntimeBehavior::default(),
+    ))];
+    let manager = ModelManager::open(
+        repository.clone(),
+        good,
+        ModelManagerConfig {
+            max_loaded_models: 2,
+            max_memory_mb: 127,
+            max_vram_mb: 1,
+        },
+    )
+    .await
+    .unwrap();
+    let model_a = identity("model-a", "1", "rev-a");
+    let model_b = identity("model-b", "2", "rev-b");
+    manager.preload(&model_a, 20).await.unwrap();
+    let generation_a = manager.activate(&model_a, 21).await.unwrap();
+    assert_eq!(manager.activate(&model_a, 22).await.unwrap(), generation_a);
+    assert_eq!(
+        manager.preload(&model_b, 23).await.unwrap_err().code,
+        "model_runtime_budget_exceeded"
+    );
+    assert_eq!(
+        manager.capture(CAPABILITY).await.unwrap().identity(),
+        &model_a
+    );
+
+    let manager = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(FakeRuntimeProvider::new(
+            "fake",
+            FakeRuntimeBehavior::default(),
+        ))],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    manager.preload(&model_a, 24).await.unwrap();
+    manager.preload(&model_b, 25).await.unwrap();
+    manager.activate(&model_a, 26).await.unwrap();
+    manager.activate(&model_b, 27).await.unwrap();
+    let rollback_generation = manager.rollback(CAPABILITY, 28).await.unwrap();
+    let restored = manager.capture(CAPABILITY).await.unwrap();
+    assert_eq!(restored.identity(), &model_a);
+    assert_eq!(restored.generation(), rollback_generation);
+    drop(restored);
+    drop(manager);
+
+    let restarted = ModelManager::open(
+        repository.clone(),
+        vec![Arc::new(FakeRuntimeProvider::new(
+            "fake",
+            FakeRuntimeBehavior::default(),
+        ))],
+        ModelManagerConfig::default(),
+    )
+    .await
+    .unwrap();
+    let restored = restarted.capture(CAPABILITY).await.unwrap();
+    assert_eq!(restored.identity(), &model_a);
+    assert_eq!(restored.generation(), rollback_generation);
+    drop(restored);
+    restarted.preload(&model_b, 29).await.unwrap();
+    assert!(restarted.activate(&model_b, 30).await.unwrap() > rollback_generation);
+    repository.close().await;
+}
+
+#[tokio::test]
+async fn preload_and_self_test_failure_leave_existing_active_model_unchanged() {
+    for behavior in [
+        FakeRuntimeBehavior {
+            fail_preload_model: Some("model-b".to_string()),
+            ..FakeRuntimeBehavior::default()
+        },
+        FakeRuntimeBehavior {
+            fail_self_test_model: Some("model-b".to_string()),
+            ..FakeRuntimeBehavior::default()
+        },
+    ] {
+        let root = TestRoot::new("runtime-failure");
+        let repository = repository_with_models(&root).await;
+        let manager = ModelManager::open(
+            repository.clone(),
+            vec![Arc::new(FakeRuntimeProvider::new("fake", behavior))],
+            ModelManagerConfig::default(),
+        )
+        .await
+        .unwrap();
+        let model_a = identity("model-a", "1", "rev-a");
+        let model_b = identity("model-b", "2", "rev-b");
+        manager.preload(&model_a, 30).await.unwrap();
+        manager.activate(&model_a, 31).await.unwrap();
+        assert!(manager.preload(&model_b, 32).await.is_err());
+        assert_eq!(
+            manager.capture(CAPABILITY).await.unwrap().identity(),
+            &model_a
+        );
+        repository.close().await;
+    }
+}


### PR DESCRIPTION
## Scope

Implements the Wave 1 / Phase 1 foundation tracked by epimore/gmv_docs#3:

- signed Model Package v1 manifest and bounded verification
- immutable SQLite-backed ModelRepository
- RuntimeProvider / ModelInstance contracts with deterministic fake runtime
- bounded ModelManager preload, self-test, health, atomic generation activation, rollback, drain/unload, and restart recovery
- concurrency and negative-path harness

This PR intentionally does not integrate TaskManager/ProviderRegistry, add local management UDS, or add a real ONNX/external provider; those are later EP-03 work listed in the private v3 tracker.

## Verification

- cargo fmt --all --check
- cargo check -p gmv-protocol
- cargo test -p gmv-protocol
- cargo check -p avai
- cargo test -p avai
- cargo clippy -p avai --all-targets -- -D warnings

All passed locally.