### PR TITLE
feat: add component-owned drain management contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,6 +1501,7 @@ dependencies = [
  "base_rpc",
  "gmv-protocol",
  "sys_metrics",
+ "tokio",
  "tokio-stream",
  "tonic",
  "uuid",

--- a/avai/config.yml
+++ b/avai/config.yml
@@ -12,6 +12,8 @@ guard:
 
 server:
   installation_id: local-installation
+  management_component_id: avai
+  management_socket: /run/gmv/avai-management.sock
   host_id: local-host
   node_id: avai-node-1
   host: 127.0.0.1

--- a/avai/src/app.rs
+++ b/avai/src/app.rs
@@ -13,6 +13,7 @@ use base::daemon::Daemon;
 use base::exception::{GlobalError, GlobalResult};
 use base::serde::Deserialize;
 use base::utils::rt::{GlobalRuntime, RuntimeType};
+use gmv_nodec::component_management::{ComponentDrainBehavior, ManagedDrainOwner, serve_uds};
 use gmv_nodec::{NodeReporter, NodeReporterConfig, generate_instance_id};
 use gmv_protocol::avai::v1::avai_control_server::AvaiControlServer;
 
@@ -69,6 +70,10 @@ struct ServerConf {
     allow_private_image_urls: bool,
     #[serde(default)]
     allowed_internal_hosts: Vec<String>,
+    #[serde(default)]
+    management_socket: Option<PathBuf>,
+    #[serde(default = "default_management_component_id")]
+    management_component_id: String,
 }
 
 impl CheckFromConf for ServerConf {
@@ -86,6 +91,24 @@ impl CheckFromConf for ServerConf {
         if self.task_queue_size == 0 || self.task_worker_count == 0 || self.max_image_bytes == 0 {
             return Err(FieldCheckError::BizError(
                 "Avai task capacity values must be positive".to_string(),
+            ));
+        }
+        if let Some(socket) = &self.management_socket
+            && (!socket.is_absolute()
+                || socket.components().any(|part| {
+                    matches!(
+                        part,
+                        std::path::Component::CurDir | std::path::Component::ParentDir
+                    )
+                }))
+        {
+            return Err(FieldCheckError::BizError(
+                "server.management_socket must be an absolute normalized path".to_string(),
+            ));
+        }
+        if self.management_component_id.trim().is_empty() {
+            return Err(FieldCheckError::BizError(
+                "server.management_component_id must not be empty".to_string(),
             ));
         }
         Ok(())
@@ -215,6 +238,20 @@ async fn run_service(app: App, bootstrap: Bootstrap, runtime: GlobalRuntime) -> 
     let event_sender = NodeReporter::spawn_managed_with_events(&runtime, reporter, cancel.clone())?;
     manager.set_event_sender(event_sender).await;
 
+    if let Some(socket) = server.management_socket.clone() {
+        let owner = Arc::new(ManagedDrainOwner::new(
+            server.management_component_id.clone(),
+            Arc::new(AvaiDrainBehavior(manager.clone())),
+        ));
+        let management_cancel = cancel.clone();
+        runtime.spawn("avai-component-management", async move {
+            if let Err(error) = serve_uds(&socket, owner, management_cancel).await {
+                base::log::error!("Avai component management failed: {error}");
+                GlobalRuntime::request_shutdown_with_error();
+            }
+        })?;
+    }
+
     let upload_listener = base::tokio::net::TcpListener::from_std(bootstrap.upload_listener)
         .map_err(external_error)?;
     let upload_cancel = cancel.clone();
@@ -340,6 +377,37 @@ fn default_task_queue_size() -> usize {
 
 fn default_task_worker_count() -> usize {
     2
+}
+
+fn default_management_component_id() -> String {
+    "avai".to_string()
+}
+
+struct AvaiDrainBehavior(TaskManager);
+
+#[tonic::async_trait]
+impl ComponentDrainBehavior for AvaiDrainBehavior {
+    fn supported(&self) -> bool {
+        true
+    }
+
+    fn close_admission(&self) {
+        self.0.close_upgrade_admission();
+    }
+
+    async fn is_drained(&self) -> bool {
+        self.0.is_upgrade_drained().await.unwrap_or(false)
+    }
+
+    async fn drain_owned_resources(&self) -> Result<(), &'static str> {
+        loop {
+            match self.0.is_upgrade_drained().await {
+                Ok(true) => return Ok(()),
+                Ok(false) => base::tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+                Err(_) => return Err("avai_drain_state_unavailable"),
+            }
+        }
+    }
 }
 
 fn config_error(error: base::cfg_lib::conf::ConfigError) -> GlobalError {

--- a/avai/src/app.rs
+++ b/avai/src/app.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use avai::guard_integration::{AvaiControlRpc, AvaiGuardNode};
 use avai::source::SourcePolicy;
-use avai::task::{TaskManager, TaskManagerConfig};
+use avai::task::{AvaiDrainBehavior, TaskManager, TaskManagerConfig};
 use avai::upload::{UploadManager, UploadManagerConfig};
 use base::cfg_lib::conf::{CheckFromConf, FieldCheckError};
 use base::cfg_lib::{CliBasic, conf, default_cli_basic};
@@ -13,7 +13,7 @@ use base::daemon::Daemon;
 use base::exception::{GlobalError, GlobalResult};
 use base::serde::Deserialize;
 use base::utils::rt::{GlobalRuntime, RuntimeType};
-use gmv_nodec::component_management::{ComponentDrainBehavior, ManagedDrainOwner, serve_uds};
+use gmv_nodec::component_management::{ManagedDrainOwner, serve_uds};
 use gmv_nodec::{NodeReporter, NodeReporterConfig, generate_instance_id};
 use gmv_protocol::avai::v1::avai_control_server::AvaiControlServer;
 
@@ -381,33 +381,6 @@ fn default_task_worker_count() -> usize {
 
 fn default_management_component_id() -> String {
     "avai".to_string()
-}
-
-struct AvaiDrainBehavior(TaskManager);
-
-#[tonic::async_trait]
-impl ComponentDrainBehavior for AvaiDrainBehavior {
-    fn supported(&self) -> bool {
-        true
-    }
-
-    fn close_admission(&self) {
-        self.0.close_upgrade_admission();
-    }
-
-    async fn is_drained(&self) -> bool {
-        self.0.is_upgrade_drained().await.unwrap_or(false)
-    }
-
-    async fn drain_owned_resources(&self) -> Result<(), &'static str> {
-        loop {
-            match self.0.is_upgrade_drained().await {
-                Ok(true) => return Ok(()),
-                Ok(false) => base::tokio::time::sleep(std::time::Duration::from_millis(10)).await,
-                Err(_) => return Err("avai_drain_state_unavailable"),
-            }
-        }
-    }
 }
 
 fn config_error(error: base::cfg_lib::conf::ConfigError) -> GlobalError {

--- a/avai/src/task.rs
+++ b/avai/src/task.rs
@@ -18,7 +18,10 @@ use base_db::{
     dbx::{DatabasePoolConfig, sqlitex::SqliteConnectionConfig},
     sqlx::{Row, SqlitePool},
 };
-use gmv_nodec::NodeEventSender;
+use gmv_nodec::{
+    NodeEventSender,
+    component_management::{AdmissionBarrier, ComponentDrainBehavior},
+};
 use gmv_protocol::{
     avai::v1::{
         AiTaskResult, AiTaskState, CancelTaskRequest, CancelTaskResponse, CreateTaskRequest,
@@ -94,7 +97,16 @@ pub struct TaskManager {
     event_sender: Arc<RwLock<Option<NodeEventSender>>>,
     running: Arc<AtomicUsize>,
     closed: Arc<AtomicBool>,
-    accepting: Arc<AtomicBool>,
+    admission: AdmissionBarrier,
+    #[cfg(test)]
+    admission_pause: Arc<std::sync::Mutex<Option<AdmissionPause>>>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct AdmissionPause {
+    entered: Arc<base::tokio::sync::Semaphore>,
+    release: Arc<base::tokio::sync::Semaphore>,
 }
 
 impl TaskManager {
@@ -157,7 +169,9 @@ impl TaskManager {
             event_sender,
             running,
             closed: Arc::new(AtomicBool::new(false)),
-            accepting: Arc::new(AtomicBool::new(true)),
+            admission: AdmissionBarrier::default(),
+            #[cfg(test)]
+            admission_pause: Arc::new(std::sync::Mutex::new(None)),
         };
         if !pending.is_empty() {
             let recovery_queue = manager.queue.clone();
@@ -193,11 +207,19 @@ impl TaskManager {
     }
 
     pub fn close_upgrade_admission(&self) {
-        self.accepting.store(false, Ordering::Release);
+        self.admission.close();
+    }
+
+    pub fn in_flight_upgrade_admissions(&self) -> usize {
+        self.admission.in_flight()
+    }
+
+    pub async fn wait_for_upgrade_admissions(&self) {
+        self.admission.wait_for_zero().await;
     }
 
     pub async fn is_upgrade_drained(&self) -> Result<bool, TaskError> {
-        Ok(self.repository.nonterminal_task_count().await? == 0)
+        Ok(self.admission.in_flight() == 0 && self.repository.nonterminal_task_count().await? == 0)
     }
 
     pub async fn create_task(
@@ -220,20 +242,26 @@ impl TaskManager {
         request: CreateTaskRequest,
         now_epoch_ms: i64,
     ) -> Result<TaskRecord, TaskError> {
-        if self.closed.load(Ordering::Acquire) || !self.accepting.load(Ordering::Acquire) {
+        if self.closed.load(Ordering::Acquire) {
             return Err(TaskError::new(
-                if self.closed.load(Ordering::Acquire) {
-                    "executor_unavailable"
-                } else {
-                    "component_draining"
-                },
-                if self.closed.load(Ordering::Acquire) {
-                    "Avai task manager is stopping"
-                } else {
-                    "Avai is draining for upgrade"
-                },
+                "executor_unavailable",
+                "Avai task manager is stopping",
             ));
         }
+        let Some(_permit) = self.admission.acquire() else {
+            return Err(TaskError::new(
+                "component_draining",
+                "Avai is draining for upgrade",
+            ));
+        };
+        if self.closed.load(Ordering::Acquire) {
+            return Err(TaskError::new(
+                "executor_unavailable",
+                "Avai task manager is stopping",
+            ));
+        }
+        #[cfg(test)]
+        self.pause_after_admission().await;
         validate_request(&request, &self.identity, &self.capabilities, now_epoch_ms)?;
         let request_hash = request_hash(&request);
         let task_id = request.task_id.clone();
@@ -360,6 +388,7 @@ impl TaskManager {
 
     pub async fn close_and_wait(&self) -> Result<(), TaskError> {
         let already_closed = self.closed.swap(true, Ordering::AcqRel);
+        self.admission.close();
         self.cancel.cancel();
         if already_closed {
             return Ok(());
@@ -372,6 +401,54 @@ impl TaskManager {
         }
         self.repository.close().await;
         Ok(())
+    }
+
+    #[cfg(test)]
+    async fn pause_after_admission(&self) {
+        let pause = self
+            .admission_pause
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if let Some(pause) = pause {
+            pause.entered.add_permits(1);
+            pause.release.acquire().await.unwrap().forget();
+        }
+    }
+}
+
+pub struct AvaiDrainBehavior(pub TaskManager);
+
+#[tonic::async_trait]
+impl ComponentDrainBehavior for AvaiDrainBehavior {
+    fn supported(&self) -> bool {
+        true
+    }
+
+    fn close_admission(&self) {
+        self.0.close_upgrade_admission();
+    }
+
+    fn in_flight_admissions(&self) -> usize {
+        self.0.in_flight_upgrade_admissions()
+    }
+
+    async fn wait_for_admissions(&self) {
+        self.0.wait_for_upgrade_admissions().await;
+    }
+
+    async fn is_drained(&self) -> bool {
+        self.0.is_upgrade_drained().await.unwrap_or(false)
+    }
+
+    async fn drain_owned_resources(&self) -> Result<(), &'static str> {
+        loop {
+            match self.0.is_upgrade_drained().await {
+                Ok(true) => return Ok(()),
+                Ok(false) => base::tokio::time::sleep(std::time::Duration::from_millis(10)).await,
+                Err(_) => return Err("avai_drain_state_unavailable"),
+            }
+        }
     }
 }
 
@@ -1191,6 +1268,7 @@ mod tests {
         transport::MessageTransport,
         uds::{ManagedUnixStreamListener, UnixTransportConfig},
     };
+    use gmv_nodec::component_management::{ComponentDrainOwner, ManagedDrainOwner};
     #[cfg(unix)]
     use gmv_protocol::session::v1::{ReadGrantedImageRequest, ReadGrantedImageResponse};
     use gmv_protocol::{
@@ -1198,6 +1276,9 @@ mod tests {
         common::v1::{
             AccessGrant, DataEndpoint, NodeKind, OperationRef, ResourceRef, TransportCapabilities,
             TransportMode,
+        },
+        component_management::v1::{
+            ComponentDrainOutcome, ComponentOwnerState, DrainRequest, PrepareForUpgradeRequest,
         },
     };
     use std::{io::Write, time::Duration};
@@ -1436,6 +1517,70 @@ mod tests {
         assert_eq!(response.state, AiTaskState::Failed as i32);
         assert_eq!(response.error.unwrap().code, "component_draining");
         assert!(manager.is_upgrade_drained().await.unwrap());
+        manager.close_and_wait().await.unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn admitted_create_cannot_cross_terminal_upgrade_drain() {
+        let (manager, root) = test_manager().await;
+        let entered = Arc::new(base::tokio::sync::Semaphore::new(0));
+        let release = Arc::new(base::tokio::sync::Semaphore::new(0));
+        *manager
+            .admission_pause
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(AdmissionPause {
+            entered: entered.clone(),
+            release: release.clone(),
+        });
+        let create_manager = manager.clone();
+        let create = base::tokio::spawn(async move {
+            create_manager
+                .create_task(test_request("task-admitted-before-drain"), now_epoch_ms())
+                .await
+        });
+        entered.acquire().await.unwrap().forget();
+        assert_eq!(manager.in_flight_upgrade_admissions(), 1);
+
+        let owner = ManagedDrainOwner::new("avai", Arc::new(AvaiDrainBehavior(manager.clone())));
+        let prepared = owner
+            .prepare_for_upgrade(PrepareForUpgradeRequest {
+                operation_id: "op-admission-race".into(),
+                component_id: "avai".into(),
+                deadline_epoch_ms: now_epoch_ms() + 10_000,
+            })
+            .await;
+        assert_eq!(prepared.owner_state, ComponentOwnerState::Draining as i32);
+        assert_eq!(prepared.outcome, ComponentDrainOutcome::Accepted as i32);
+        assert!(!manager.is_upgrade_drained().await.unwrap());
+
+        let rejected = manager
+            .create_task(test_request("task-after-close"), now_epoch_ms())
+            .await;
+        assert_eq!(rejected.error.unwrap().code, "component_draining");
+
+        release.add_permits(1);
+        let created = create.await.unwrap();
+        assert_eq!(created.task_id, "task-admitted-before-drain");
+        let drained = owner
+            .drain(DrainRequest {
+                operation_id: "op-admission-race".into(),
+                component_id: "avai".into(),
+                deadline_epoch_ms: now_epoch_ms() + 10_000,
+            })
+            .await;
+        assert_eq!(drained.owner_state, ComponentOwnerState::Drained as i32);
+        assert_eq!(manager.in_flight_upgrade_admissions(), 0);
+        assert!(manager.is_upgrade_drained().await.unwrap());
+        assert_eq!(
+            manager
+                .create_task(test_request("task-after-drained"), now_epoch_ms())
+                .await
+                .error
+                .unwrap()
+                .code,
+            "component_draining"
+        );
         manager.close_and_wait().await.unwrap();
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/avai/src/task.rs
+++ b/avai/src/task.rs
@@ -94,6 +94,7 @@ pub struct TaskManager {
     event_sender: Arc<RwLock<Option<NodeEventSender>>>,
     running: Arc<AtomicUsize>,
     closed: Arc<AtomicBool>,
+    accepting: Arc<AtomicBool>,
 }
 
 impl TaskManager {
@@ -156,6 +157,7 @@ impl TaskManager {
             event_sender,
             running,
             closed: Arc::new(AtomicBool::new(false)),
+            accepting: Arc::new(AtomicBool::new(true)),
         };
         if !pending.is_empty() {
             let recovery_queue = manager.queue.clone();
@@ -190,6 +192,14 @@ impl TaskManager {
         self.running.load(Ordering::Acquire)
     }
 
+    pub fn close_upgrade_admission(&self) {
+        self.accepting.store(false, Ordering::Release);
+    }
+
+    pub async fn is_upgrade_drained(&self) -> Result<bool, TaskError> {
+        Ok(self.repository.nonterminal_task_count().await? == 0)
+    }
+
     pub async fn create_task(
         &self,
         request: CreateTaskRequest,
@@ -210,10 +220,18 @@ impl TaskManager {
         request: CreateTaskRequest,
         now_epoch_ms: i64,
     ) -> Result<TaskRecord, TaskError> {
-        if self.closed.load(Ordering::Acquire) {
+        if self.closed.load(Ordering::Acquire) || !self.accepting.load(Ordering::Acquire) {
             return Err(TaskError::new(
-                "executor_unavailable",
-                "Avai task manager is stopping",
+                if self.closed.load(Ordering::Acquire) {
+                    "executor_unavailable"
+                } else {
+                    "component_draining"
+                },
+                if self.closed.load(Ordering::Acquire) {
+                    "Avai task manager is stopping"
+                } else {
+                    "Avai is draining for upgrade"
+                },
             ));
         }
         validate_request(&request, &self.identity, &self.capabilities, now_epoch_ms)?;
@@ -788,6 +806,17 @@ impl TaskRepository {
                     .map_err(|error| TaskError::internal("decode_pending", error))
             })
             .collect()
+    }
+
+    async fn nonterminal_task_count(&self) -> Result<usize, TaskError> {
+        let count: i64 =
+            base_db::sqlx::query_scalar("SELECT COUNT(*) FROM avai_task WHERE state IN (?, ?)")
+                .bind(AiTaskState::Pending as i32)
+                .bind(AiTaskState::Running as i32)
+                .fetch_one(&self.pool)
+                .await
+                .map_err(|error| TaskError::internal("count_nonterminal", error))?;
+        usize::try_from(count).map_err(|error| TaskError::internal("decode_nonterminal", error))
     }
 
     async fn insert_or_get(
@@ -1394,6 +1423,20 @@ mod tests {
             vec!["task-recovery".to_string()]
         );
         reopened.pool.close().await;
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn upgrade_admission_rejects_new_tasks_without_closing_workers() {
+        let (manager, root) = test_manager().await;
+        manager.close_upgrade_admission();
+        let response = manager
+            .create_task(test_request("task-after-drain"), now_epoch_ms())
+            .await;
+        assert_eq!(response.state, AiTaskState::Failed as i32);
+        assert_eq!(response.error.unwrap().code, "component_draining");
+        assert!(manager.is_upgrade_drained().await.unwrap());
+        manager.close_and_wait().await.unwrap();
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/guard/server/config.yml
+++ b/guard/server/config.yml
@@ -15,6 +15,8 @@ log:
       level: warn #日志等级
 
 guard:
+  management_component_id: guard
+  management_socket: /run/gmv/guard-management.sock
   http:
     bind_addr: 0.0.0.0:8080
     origins:

--- a/guard/server/src/app.rs
+++ b/guard/server/src/app.rs
@@ -9,6 +9,7 @@ use base::log::{debug, error, info, warn};
 use base::logger;
 use base::logger::episode::{EpisodeDecision, FailureEpisode};
 use base::utils::rt::{GlobalRuntime, RuntimeType};
+use gmv_nodec::component_management::{UnsupportedDrainOwner, serve_uds};
 use sha2::{Digest, Sha256};
 
 use crate::api::v2::ApiV2;
@@ -99,6 +100,18 @@ pub async fn start_guard(
     listeners: GuardListeners,
     runtime: GlobalRuntime,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if let Some(socket) = config.management_socket.clone() {
+        let owner = Arc::new(UnsupportedDrainOwner::new(
+            config.management_component_id.clone(),
+        ));
+        let management_cancel = runtime.cancel.clone();
+        runtime.spawn("guard-component-management", async move {
+            if let Err(error) = serve_uds(&socket, owner, management_cancel).await {
+                base::log::error!("Guard component management failed: {error}");
+                GlobalRuntime::request_shutdown_with_error();
+            }
+        })?;
+    }
     let web_config = WebServerConfig::from_app(&config)?;
     let persistent = PersistentStore::connect(&config).await?;
     persistent.initialize(&config).await?;

--- a/guard/server/src/app_config.rs
+++ b/guard/server/src/app_config.rs
@@ -24,6 +24,10 @@ pub struct GuardAppConfig {
     pub database: DatabaseConfig,
     #[serde(default)]
     pub bootstrap: BootstrapConfig,
+    #[serde(default)]
+    pub management_socket: Option<PathBuf>,
+    #[serde(default = "default_management_component_id")]
+    pub management_component_id: String,
 }
 
 impl GuardAppConfig {
@@ -43,8 +47,31 @@ impl GuardAppConfig {
         self.grpc.validate()?;
         self.registry.validate()?;
         self.database.validate()?;
-        self.bootstrap.validate()
+        self.bootstrap.validate()?;
+        if self.management_component_id.trim().is_empty() {
+            return Err(GuardError::InvalidConfig(
+                "guard.management_component_id must not be empty".to_string(),
+            ));
+        }
+        if let Some(socket) = &self.management_socket
+            && (!socket.is_absolute()
+                || socket.components().any(|part| {
+                    matches!(
+                        part,
+                        std::path::Component::CurDir | std::path::Component::ParentDir
+                    )
+                }))
+        {
+            return Err(GuardError::InvalidConfig(
+                "guard.management_socket must be an absolute normalized path".to_string(),
+            ));
+        }
+        Ok(())
     }
+}
+
+fn default_management_component_id() -> String {
+    "guard".to_string()
 }
 
 impl CheckFromConf for GuardAppConfig {

--- a/session/gb28181/config.yml
+++ b/session/gb28181/config.yml
@@ -65,6 +65,8 @@ guard:
 
 server:
     grpc:
+        management_component_id: session
+        management_socket: /run/gmv/session-management.sock
         listen_addr: 127.0.0.1:19081 #本机control gRPC实际监听地址
         advertised_url: http://127.0.0.1:19081 #注册给guard和Stream回调使用的完整可达地址；scheme独立于本机TLS
         tls:

--- a/session/gb28181/src/app.rs
+++ b/session/gb28181/src/app.rs
@@ -16,6 +16,7 @@ use crate::guard_integration::{
     init_guard_event_sender,
 };
 use crate::register::core::Register;
+use gmv_nodec::component_management::{UnsupportedDrainOwner, serve_uds};
 use gmv_nodec::{NodeReporter, NodeReporterConfig, generate_instance_id};
 use gmv_protocol::common::v1::{Endpoint, EndpointMode};
 use gmv_protocol::guard::v1::NodeResourceSnapshot;
@@ -119,6 +120,8 @@ impl
             .public_endpoint()
             .expect("validated session HTTP public URL");
         let grpc = crate::state::SessionGrpcConf::get();
+        let management_socket = grpc.management_socket.clone();
+        let management_component_id = grpc.management_component_id.clone();
         let (grpc_advertised_tls, grpc_advertised_host, grpc_advertised_port) = grpc
             .advertised_endpoint()
             .expect("validated session gRPC advertised URL");
@@ -127,6 +130,20 @@ impl
         let network_rt = GlobalRuntime::register_default(RuntimeType::CommonNetwork)?;
         let service_rt = network_rt.clone();
         network_rt.spawn("session-service", async move {
+            if let Some(socket) = management_socket {
+                let owner = Arc::new(UnsupportedDrainOwner::new(management_component_id));
+                let management_cancel = service_rt.cancel.clone();
+                if let Err(err) = service_rt.spawn("session-component-management", async move {
+                    if let Err(error) = serve_uds(&socket, owner, management_cancel).await {
+                        error!("session component management failed: {error}");
+                        GlobalRuntime::request_shutdown_with_error();
+                    }
+                }) {
+                    error!("spawn session component management task failed: {err}");
+                    GlobalRuntime::request_shutdown_with_error();
+                    return;
+                }
+            }
             if let Err(err) = SessionConf::run(tu, &service_rt).await {
                 error!("GB28181 session initialization failed: {err}");
                 GlobalRuntime::request_shutdown_with_error();

--- a/session/gb28181/src/state/mod.rs
+++ b/session/gb28181/src/state/mod.rs
@@ -21,6 +21,10 @@ pub struct SessionGrpcConf {
     pub advertised_url: String,
     #[serde(default)]
     pub tls: GrpcTlsConf,
+    #[serde(default)]
+    pub management_socket: Option<PathBuf>,
+    #[serde(default = "default_management_component_id")]
+    pub management_component_id: String,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -66,8 +70,30 @@ impl CheckFromConf for SessionGrpcConf {
                 "server.grpc.tls启用时certificate_path和private_key_path不能为空".to_string(),
             ));
         }
+        if self.management_component_id.trim().is_empty() {
+            return Err(FieldCheckError::BizError(
+                "server.grpc.management_component_id不能为空".to_string(),
+            ));
+        }
+        if let Some(socket) = &self.management_socket
+            && (!socket.is_absolute()
+                || socket.components().any(|part| {
+                    matches!(
+                        part,
+                        std::path::Component::CurDir | std::path::Component::ParentDir
+                    )
+                }))
+        {
+            return Err(FieldCheckError::BizError(
+                "server.grpc.management_socket必须是规范化绝对路径".to_string(),
+            ));
+        }
         Ok(())
     }
+}
+
+fn default_management_component_id() -> String {
+    "session".to_string()
 }
 
 impl SessionGrpcConf {
@@ -321,6 +347,8 @@ mod tests {
             listen_addr: "127.0.0.1:19081".parse().unwrap(),
             advertised_url: "https://session-rpc.example.com:443".to_string(),
             tls: GrpcTlsConf::default(),
+            management_socket: None,
+            management_component_id: "session".to_string(),
         };
 
         assert_eq!(

--- a/shared/nodec/Cargo.toml
+++ b/shared/nodec/Cargo.toml
@@ -15,3 +15,6 @@ sys_metrics = { path = "../../../pigs/sys_metrics" }
 tonic = "0.14"
 tokio-stream = "0.1"
 uuid = { version = "1.23", features = ["v7"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/shared/nodec/src/component_management.rs
+++ b/shared/nodec/src/component_management.rs
@@ -1,4 +1,8 @@
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use base::tokio_util::sync::CancellationToken;
 use gmv_protocol::component_management::v1::{
@@ -23,8 +27,101 @@ pub trait ComponentDrainOwner: Send + Sync + 'static {
 pub trait ComponentDrainBehavior: Send + Sync + 'static {
     fn supported(&self) -> bool;
     fn close_admission(&self);
+    fn in_flight_admissions(&self) -> usize;
+    async fn wait_for_admissions(&self);
     async fn is_drained(&self) -> bool;
     async fn drain_owned_resources(&self) -> Result<(), &'static str>;
+}
+
+#[derive(Default)]
+struct AdmissionState {
+    accepting: bool,
+    in_flight: usize,
+}
+
+struct AdmissionInner {
+    state: Mutex<AdmissionState>,
+    zero: base::tokio::sync::Notify,
+}
+
+#[derive(Clone)]
+pub struct AdmissionBarrier {
+    inner: Arc<AdmissionInner>,
+}
+
+impl Default for AdmissionBarrier {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(AdmissionInner {
+                state: Mutex::new(AdmissionState {
+                    accepting: true,
+                    in_flight: 0,
+                }),
+                zero: base::tokio::sync::Notify::new(),
+            }),
+        }
+    }
+}
+
+impl AdmissionBarrier {
+    pub fn acquire(&self) -> Option<AdmissionPermit> {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !state.accepting {
+            return None;
+        }
+        state.in_flight += 1;
+        Some(AdmissionPermit {
+            inner: self.inner.clone(),
+        })
+    }
+
+    pub fn close(&self) {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .accepting = false;
+    }
+
+    pub fn in_flight(&self) -> usize {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .in_flight
+    }
+
+    pub async fn wait_for_zero(&self) {
+        loop {
+            let notified = self.inner.zero.notified();
+            if self.in_flight() == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+pub struct AdmissionPermit {
+    inner: Arc<AdmissionInner>,
+}
+
+impl Drop for AdmissionPermit {
+    fn drop(&mut self) {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.in_flight -= 1;
+        if state.in_flight == 0 {
+            self.inner.zero.notify_waiters();
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -146,7 +243,7 @@ impl<B: ComponentDrainBehavior> ComponentDrainOwner for ManagedDrainOwner<B> {
             );
         }
         self.behavior.close_admission();
-        let drained = self.behavior.is_drained().await;
+        let drained = self.behavior.in_flight_admissions() == 0 && self.behavior.is_drained().await;
         *generation = Some(Generation {
             operation_id: request.operation_id.clone(),
             drained,
@@ -157,8 +254,9 @@ impl<B: ComponentDrainBehavior> ComponentDrainOwner for ManagedDrainOwner<B> {
             let generation = self.generation.clone();
             let operation_id = request.operation_id.clone();
             base::tokio::spawn(async move {
+                behavior.wait_for_admissions().await;
                 let result = behavior.drain_owned_resources().await;
-                let drained = behavior.is_drained().await;
+                let drained = behavior.in_flight_admissions() == 0 && behavior.is_drained().await;
                 let mut generation = generation.lock().await;
                 if let Some(current) = generation.as_mut()
                     && current.operation_id == operation_id
@@ -386,11 +484,11 @@ pub async fn serve_uds<O: ComponentDrainOwner>(
         std::fs::create_dir_all(parent)
             .map_err(|error| base::exception::GlobalError::from_external_error(error, |_| {}))?;
     }
-    let listener = base::tokio::net::UnixListener::bind(socket)
-        .map_err(|error| base::exception::GlobalError::from_external_error(error, |_| {}))?;
+    let listener = bind_uds_listener(socket).await?;
     use std::os::unix::fs::PermissionsExt;
     std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o600))
         .map_err(|error| base::exception::GlobalError::from_external_error(error, |_| {}))?;
+    let owned_socket = socket_identity(socket)?;
     let incoming = stream::unfold(listener, |listener| async move {
         Some((listener.accept().await.map(|(stream, _)| stream), listener))
     });
@@ -400,26 +498,88 @@ pub async fn serve_uds<O: ComponentDrainOwner>(
         )))
         .serve_with_incoming_shutdown(incoming, async move { cancel.cancelled().await })
         .await;
-    match std::fs::remove_file(socket) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(base::exception::GlobalError::from_external_error(
-                error,
-                |_| {},
-            ));
-        }
-    }
+    remove_owned_socket(socket, owned_socket)?;
     result.map_err(|error| base::exception::GlobalError::from_external_error(error, |_| {}))
+}
+
+#[cfg(unix)]
+async fn bind_uds_listener(
+    socket: &Path,
+) -> base::exception::GlobalResult<base::tokio::net::UnixListener> {
+    match base::tokio::net::UnixListener::bind(socket) {
+        Ok(listener) => Ok(listener),
+        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => {
+            let stale_identity = socket_identity(socket)?;
+            match base::tokio::net::UnixStream::connect(socket).await {
+                Ok(_) => Err(io_error(std::io::Error::new(
+                    std::io::ErrorKind::AddrInUse,
+                    "component management socket is active",
+                ))),
+                Err(connect_error)
+                    if connect_error.kind() == std::io::ErrorKind::ConnectionRefused =>
+                {
+                    if socket_identity(socket)? != stale_identity {
+                        return Err(io_error(std::io::Error::new(
+                            std::io::ErrorKind::AddrInUse,
+                            "component management socket changed during stale recovery",
+                        )));
+                    }
+                    std::fs::remove_file(socket).map_err(io_error)?;
+                    base::tokio::net::UnixListener::bind(socket).map_err(io_error)
+                }
+                Err(connect_error) => Err(io_error(connect_error)),
+            }
+        }
+        Err(error) => Err(io_error(error)),
+    }
+}
+
+#[cfg(unix)]
+fn socket_identity(socket: &Path) -> base::exception::GlobalResult<(u64, u64)> {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let metadata = std::fs::symlink_metadata(socket).map_err(io_error)?;
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_socket() {
+        return Err(io_error(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            "component management path is not a socket",
+        )));
+    }
+    Ok((metadata.dev(), metadata.ino()))
+}
+
+#[cfg(unix)]
+fn remove_owned_socket(
+    socket: &Path,
+    owned_identity: (u64, u64),
+) -> base::exception::GlobalResult<()> {
+    match std::fs::symlink_metadata(socket) {
+        Ok(_) if socket_identity(socket)? == owned_identity => {
+            std::fs::remove_file(socket).map_err(io_error)
+        }
+        Ok(_) => Err(io_error(std::io::Error::new(
+            std::io::ErrorKind::AddrInUse,
+            "component management socket ownership changed before cleanup",
+        ))),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(io_error(error)),
+    }
+}
+
+#[cfg(unix)]
+fn io_error(error: std::io::Error) -> base::exception::GlobalError {
+    base::exception::GlobalError::from_external_error(error, |_| {})
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(1);
 
     struct TestBehavior {
-        accepting: AtomicBool,
+        admission: AdmissionBarrier,
         drained: AtomicBool,
         release: Option<Arc<base::tokio::sync::Notify>>,
         drain_calls: AtomicUsize,
@@ -431,7 +591,13 @@ mod tests {
             true
         }
         fn close_admission(&self) {
-            self.accepting.store(false, Ordering::Release);
+            self.admission.close();
+        }
+        fn in_flight_admissions(&self) -> usize {
+            self.admission.in_flight()
+        }
+        async fn wait_for_admissions(&self) {
+            self.admission.wait_for_zero().await;
         }
         async fn is_drained(&self) -> bool {
             self.drained.load(Ordering::Acquire)
@@ -454,7 +620,7 @@ mod tests {
     async fn replay_keeps_generation_and_conflicting_operation_is_rejected() {
         let release = Arc::new(base::tokio::sync::Notify::new());
         let behavior = Arc::new(TestBehavior {
-            accepting: AtomicBool::new(true),
+            admission: AdmissionBarrier::default(),
             drained: AtomicBool::new(false),
             release: Some(release.clone()),
             drain_calls: AtomicUsize::new(0),
@@ -505,7 +671,7 @@ mod tests {
             cross_target.outcome,
             ComponentDrainOutcome::OperationConflict as i32
         );
-        assert!(!behavior.accepting.load(Ordering::Acquire));
+        assert!(behavior.admission.acquire().is_none());
         release.notify_one();
         let first_drain = owner
             .drain(DrainRequest {
@@ -535,7 +701,7 @@ mod tests {
     #[tokio::test]
     async fn deadline_does_not_reopen_admission() {
         let behavior = Arc::new(TestBehavior {
-            accepting: AtomicBool::new(true),
+            admission: AdmissionBarrier::default(),
             drained: AtomicBool::new(false),
             release: Some(Arc::new(base::tokio::sync::Notify::new())),
             drain_calls: AtomicUsize::new(0),
@@ -560,7 +726,7 @@ mod tests {
             response.outcome,
             ComponentDrainOutcome::DeadlineExceeded as i32
         );
-        assert!(!behavior.accepting.load(Ordering::Acquire));
+        assert!(behavior.admission.acquire().is_none());
     }
 
     #[tokio::test]
@@ -591,7 +757,7 @@ mod tests {
         let owner = ManagedDrainOwner::new(
             "stream",
             Arc::new(TestBehavior {
-                accepting: AtomicBool::new(true),
+                admission: AdmissionBarrier::default(),
                 drained: AtomicBool::new(false),
                 release: None,
                 drain_calls: AtomicUsize::new(0),
@@ -606,5 +772,195 @@ mod tests {
             .await;
         assert_eq!(busy.owner_state, ComponentOwnerState::Accepting as i32);
         assert_eq!(busy.outcome, ComponentDrainOutcome::Busy as i32);
+    }
+
+    #[tokio::test]
+    async fn admitted_request_blocks_terminal_drain_until_permit_drops() {
+        let behavior = Arc::new(TestBehavior {
+            admission: AdmissionBarrier::default(),
+            drained: AtomicBool::new(true),
+            release: None,
+            drain_calls: AtomicUsize::new(0),
+        });
+        let permit = behavior.admission.acquire().unwrap();
+        let owner = Arc::new(ManagedDrainOwner::new("stream", behavior.clone()));
+        let prepared = owner
+            .prepare_for_upgrade(PrepareForUpgradeRequest {
+                operation_id: "op-permit".into(),
+                component_id: "stream".into(),
+                deadline_epoch_ms: future_deadline(),
+            })
+            .await;
+        assert_eq!(prepared.owner_state, ComponentOwnerState::Draining as i32);
+        assert_eq!(prepared.outcome, ComponentDrainOutcome::Accepted as i32);
+        assert!(behavior.admission.acquire().is_none());
+
+        drop(permit);
+        let drained = owner
+            .drain(DrainRequest {
+                operation_id: "op-permit".into(),
+                component_id: "stream".into(),
+                deadline_epoch_ms: future_deadline(),
+            })
+            .await;
+        assert_eq!(drained.owner_state, ComponentOwnerState::Drained as i32);
+        assert_eq!(behavior.admission.in_flight(), 0);
+        assert!(behavior.admission.acquire().is_none());
+    }
+
+    #[cfg(unix)]
+    fn socket_test_root(name: &str) -> std::path::PathBuf {
+        let id = NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "gmv-component-management-{name}-{}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_path(path: &Path) {
+        for _ in 0..100 {
+            if path.exists() {
+                return;
+            }
+            base::tokio::task::yield_now().await;
+        }
+        panic!("socket path was not created: {}", path.display());
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_socket(path: &Path) {
+        for _ in 0..100 {
+            if base::tokio::net::UnixStream::connect(path).await.is_ok() {
+                return;
+            }
+            base::tokio::task::yield_now().await;
+        }
+        panic!("socket did not accept connections: {}", path.display());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_clean_bind_and_normal_shutdown_remove_owned_socket() {
+        let root = socket_test_root("clean");
+        let socket = root.join("management.sock");
+        let cancel = CancellationToken::new();
+        let server_socket = socket.clone();
+        let server_cancel = cancel.clone();
+        let server = base::tokio::spawn(async move {
+            serve_uds(
+                &server_socket,
+                Arc::new(UnsupportedDrainOwner::new("guard")),
+                server_cancel,
+            )
+            .await
+        });
+        wait_for_socket(&socket).await;
+        cancel.cancel();
+        server.await.unwrap().unwrap();
+        assert!(!socket.exists());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_recovers_only_a_stale_socket() {
+        let root = socket_test_root("stale");
+        let socket = root.join("management.sock");
+        let stale = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+        drop(stale);
+        let cancel = CancellationToken::new();
+        let server_socket = socket.clone();
+        let server_cancel = cancel.clone();
+        let server = base::tokio::spawn(async move {
+            serve_uds(
+                &server_socket,
+                Arc::new(UnsupportedDrainOwner::new("guard")),
+                server_cancel,
+            )
+            .await
+        });
+        wait_for_socket(&socket).await;
+        cancel.cancel();
+        server.await.unwrap().unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_active_socket_is_not_replaced() {
+        let root = socket_test_root("active");
+        let socket = root.join("management.sock");
+        let first_cancel = CancellationToken::new();
+        let first_socket = socket.clone();
+        let first_server_cancel = first_cancel.clone();
+        let first = base::tokio::spawn(async move {
+            serve_uds(
+                &first_socket,
+                Arc::new(UnsupportedDrainOwner::new("guard")),
+                first_server_cancel,
+            )
+            .await
+        });
+        wait_for_path(&socket).await;
+        let identity = socket_identity(&socket).unwrap();
+        assert!(
+            serve_uds(
+                &socket,
+                Arc::new(UnsupportedDrainOwner::new("guard")),
+                CancellationToken::new(),
+            )
+            .await
+            .is_err()
+        );
+        assert_eq!(socket_identity(&socket).unwrap(), identity);
+        assert!(base::tokio::net::UnixStream::connect(&socket).await.is_ok());
+        first_cancel.cancel();
+        first.await.unwrap().unwrap();
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn uds_regular_file_and_symlink_fail_closed() {
+        use std::os::unix::fs::symlink;
+
+        let root = socket_test_root("non-socket");
+        let regular = root.join("regular");
+        std::fs::write(&regular, b"keep").unwrap();
+        assert!(
+            serve_uds(
+                &regular,
+                Arc::new(UnsupportedDrainOwner::new("guard")),
+                CancellationToken::new(),
+            )
+            .await
+            .is_err()
+        );
+        assert_eq!(std::fs::read(&regular).unwrap(), b"keep");
+
+        let target = root.join("target");
+        std::fs::write(&target, b"target").unwrap();
+        let link = root.join("link");
+        symlink(&target, &link).unwrap();
+        assert!(
+            serve_uds(
+                &link,
+                Arc::new(UnsupportedDrainOwner::new("guard")),
+                CancellationToken::new(),
+            )
+            .await
+            .is_err()
+        );
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"target");
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/shared/nodec/src/component_management.rs
+++ b/shared/nodec/src/component_management.rs
@@ -1,0 +1,610 @@
+use std::{path::Path, sync::Arc, time::Duration};
+
+use base::tokio_util::sync::CancellationToken;
+use gmv_protocol::component_management::v1::{
+    ComponentDrainResponse, DrainRequest, PrepareForUpgradeRequest,
+    component_management_server::{ComponentManagement, ComponentManagementServer},
+};
+use tonic::{Request, Response, Status, async_trait};
+
+use gmv_protocol::component_management::v1::{ComponentDrainOutcome, ComponentOwnerState};
+
+#[async_trait]
+pub trait ComponentDrainOwner: Send + Sync + 'static {
+    async fn prepare_for_upgrade(
+        &self,
+        request: PrepareForUpgradeRequest,
+    ) -> ComponentDrainResponse;
+
+    async fn drain(&self, request: DrainRequest) -> ComponentDrainResponse;
+}
+
+#[async_trait]
+pub trait ComponentDrainBehavior: Send + Sync + 'static {
+    fn supported(&self) -> bool;
+    fn close_admission(&self);
+    async fn is_drained(&self) -> bool;
+    async fn drain_owned_resources(&self) -> Result<(), &'static str>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Generation {
+    operation_id: String,
+    drained: bool,
+    failure: Option<&'static str>,
+}
+
+pub struct ManagedDrainOwner<B> {
+    component_id: String,
+    behavior: Arc<B>,
+    generation: Arc<base::tokio::sync::Mutex<Option<Generation>>>,
+}
+
+impl<B> ManagedDrainOwner<B> {
+    pub fn new(component_id: impl Into<String>, behavior: Arc<B>) -> Self {
+        Self {
+            component_id: component_id.into(),
+            behavior,
+            generation: Arc::new(base::tokio::sync::Mutex::new(None)),
+        }
+    }
+
+    fn response(
+        &self,
+        operation_id: String,
+        state: ComponentOwnerState,
+        outcome: ComponentDrainOutcome,
+        code: &str,
+    ) -> ComponentDrainResponse {
+        ComponentDrainResponse {
+            operation_id,
+            component_id: self.component_id.clone(),
+            owner_state: state as i32,
+            outcome: outcome as i32,
+            stable_error_code: code.to_string(),
+            observed_at_epoch_ms: now_ms(),
+        }
+    }
+
+    fn validate(&self, operation_id: &str, component_id: &str) -> Option<ComponentDrainResponse> {
+        if operation_id.is_empty() {
+            return Some(self.response(
+                operation_id.to_string(),
+                ComponentOwnerState::Blocked,
+                ComponentDrainOutcome::InternalFailure,
+                "operation_id_missing",
+            ));
+        }
+        if component_id != self.component_id {
+            return Some(self.response(
+                operation_id.to_string(),
+                ComponentOwnerState::Blocked,
+                ComponentDrainOutcome::OperationConflict,
+                "component_mismatch",
+            ));
+        }
+        None
+    }
+}
+
+#[async_trait]
+impl<B: ComponentDrainBehavior> ComponentDrainOwner for ManagedDrainOwner<B> {
+    async fn prepare_for_upgrade(
+        &self,
+        request: PrepareForUpgradeRequest,
+    ) -> ComponentDrainResponse {
+        if let Some(response) = self.validate(&request.operation_id, &request.component_id) {
+            return response;
+        }
+        if !self.behavior.supported() {
+            return self.response(
+                request.operation_id,
+                ComponentOwnerState::Accepting,
+                ComponentDrainOutcome::Unsupported,
+                "component_drain_unsupported",
+            );
+        }
+        let mut generation = self.generation.lock().await;
+        if let Some(current) = generation.as_ref() {
+            if current.operation_id != request.operation_id {
+                return self.response(
+                    request.operation_id,
+                    if current.drained {
+                        ComponentOwnerState::Drained
+                    } else {
+                        ComponentOwnerState::Draining
+                    },
+                    ComponentDrainOutcome::OperationConflict,
+                    "component_drain_operation_conflict",
+                );
+            }
+            return self.response(
+                request.operation_id,
+                if current.failure.is_some() {
+                    ComponentOwnerState::Blocked
+                } else if current.drained {
+                    ComponentOwnerState::Drained
+                } else {
+                    ComponentOwnerState::Draining
+                },
+                if current.failure.is_some() {
+                    ComponentDrainOutcome::Busy
+                } else if current.drained {
+                    ComponentDrainOutcome::AlreadyDrained
+                } else {
+                    ComponentDrainOutcome::AlreadyDraining
+                },
+                current.failure.unwrap_or_default(),
+            );
+        }
+        if request.deadline_epoch_ms <= now_ms() {
+            return self.response(
+                request.operation_id,
+                ComponentOwnerState::Accepting,
+                ComponentDrainOutcome::DeadlineExceeded,
+                "component_drain_deadline_exceeded",
+            );
+        }
+        self.behavior.close_admission();
+        let drained = self.behavior.is_drained().await;
+        *generation = Some(Generation {
+            operation_id: request.operation_id.clone(),
+            drained,
+            failure: None,
+        });
+        if !drained {
+            let behavior = self.behavior.clone();
+            let generation = self.generation.clone();
+            let operation_id = request.operation_id.clone();
+            base::tokio::spawn(async move {
+                let result = behavior.drain_owned_resources().await;
+                let drained = behavior.is_drained().await;
+                let mut generation = generation.lock().await;
+                if let Some(current) = generation.as_mut()
+                    && current.operation_id == operation_id
+                {
+                    current.drained = result.is_ok() && drained;
+                    current.failure = match result {
+                        Ok(()) if drained => None,
+                        Ok(()) => Some("component_drain_incomplete"),
+                        Err(code) => Some(code),
+                    };
+                }
+            });
+        }
+        self.response(
+            request.operation_id,
+            if drained {
+                ComponentOwnerState::Drained
+            } else {
+                ComponentOwnerState::Draining
+            },
+            if drained {
+                ComponentDrainOutcome::Drained
+            } else {
+                ComponentDrainOutcome::Accepted
+            },
+            "",
+        )
+    }
+
+    async fn drain(&self, request: DrainRequest) -> ComponentDrainResponse {
+        if let Some(response) = self.validate(&request.operation_id, &request.component_id) {
+            return response;
+        }
+        if !self.behavior.supported() {
+            return self.response(
+                request.operation_id,
+                ComponentOwnerState::Accepting,
+                ComponentDrainOutcome::Unsupported,
+                "component_drain_unsupported",
+            );
+        }
+        loop {
+            let current = self.generation.lock().await.clone();
+            let Some(current) = current else {
+                return self.response(
+                    request.operation_id,
+                    ComponentOwnerState::Accepting,
+                    ComponentDrainOutcome::Busy,
+                    "component_drain_not_prepared",
+                );
+            };
+            if current.operation_id != request.operation_id {
+                return self.response(
+                    request.operation_id,
+                    if current.drained {
+                        ComponentOwnerState::Drained
+                    } else {
+                        ComponentOwnerState::Draining
+                    },
+                    ComponentDrainOutcome::OperationConflict,
+                    "component_drain_operation_conflict",
+                );
+            }
+            if current.drained {
+                return self.response(
+                    request.operation_id,
+                    ComponentOwnerState::Drained,
+                    ComponentDrainOutcome::AlreadyDrained,
+                    "",
+                );
+            }
+            if let Some(code) = current.failure {
+                return self.response(
+                    request.operation_id,
+                    ComponentOwnerState::Blocked,
+                    if code == "component_drain_incomplete" {
+                        ComponentDrainOutcome::Busy
+                    } else {
+                        ComponentDrainOutcome::InternalFailure
+                    },
+                    code,
+                );
+            }
+            let remaining_ms = request.deadline_epoch_ms.saturating_sub(now_ms());
+            if remaining_ms <= 0 {
+                return self.response(
+                    request.operation_id,
+                    ComponentOwnerState::Draining,
+                    ComponentDrainOutcome::DeadlineExceeded,
+                    "component_drain_deadline_exceeded",
+                );
+            }
+            base::tokio::time::sleep(Duration::from_millis((remaining_ms as u64).min(10))).await;
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct UnsupportedDrainOwner {
+    component_id: String,
+}
+
+impl UnsupportedDrainOwner {
+    pub fn new(component_id: impl Into<String>) -> Self {
+        Self {
+            component_id: component_id.into(),
+        }
+    }
+
+    fn response(
+        &self,
+        operation_id: String,
+        component_id: String,
+        deadline_epoch_ms: i64,
+    ) -> ComponentDrainResponse {
+        let (outcome, code) = if component_id != self.component_id {
+            (
+                ComponentDrainOutcome::OperationConflict,
+                "component_mismatch",
+            )
+        } else if deadline_epoch_ms <= now_ms() {
+            (
+                ComponentDrainOutcome::DeadlineExceeded,
+                "component_drain_deadline_exceeded",
+            )
+        } else {
+            (
+                ComponentDrainOutcome::Unsupported,
+                "component_drain_unsupported",
+            )
+        };
+        ComponentDrainResponse {
+            operation_id,
+            component_id: self.component_id.clone(),
+            owner_state: ComponentOwnerState::Accepting as i32,
+            outcome: outcome as i32,
+            stable_error_code: code.to_string(),
+            observed_at_epoch_ms: now_ms(),
+        }
+    }
+}
+
+#[async_trait]
+impl ComponentDrainOwner for UnsupportedDrainOwner {
+    async fn prepare_for_upgrade(
+        &self,
+        request: PrepareForUpgradeRequest,
+    ) -> ComponentDrainResponse {
+        self.response(
+            request.operation_id,
+            request.component_id,
+            request.deadline_epoch_ms,
+        )
+    }
+
+    async fn drain(&self, request: DrainRequest) -> ComponentDrainResponse {
+        self.response(
+            request.operation_id,
+            request.component_id,
+            request.deadline_epoch_ms,
+        )
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |duration| {
+            duration.as_millis().min(i64::MAX as u128) as i64
+        })
+}
+
+#[derive(Clone)]
+pub struct ComponentManagementRpc<O> {
+    owner: Arc<O>,
+}
+
+impl<O> ComponentManagementRpc<O> {
+    pub fn new(owner: Arc<O>) -> Self {
+        Self { owner }
+    }
+}
+
+#[async_trait]
+impl<O: ComponentDrainOwner> ComponentManagement for ComponentManagementRpc<O> {
+    async fn prepare_for_upgrade(
+        &self,
+        request: Request<PrepareForUpgradeRequest>,
+    ) -> Result<Response<ComponentDrainResponse>, Status> {
+        Ok(Response::new(
+            self.owner.prepare_for_upgrade(request.into_inner()).await,
+        ))
+    }
+
+    async fn drain(
+        &self,
+        request: Request<DrainRequest>,
+    ) -> Result<Response<ComponentDrainResponse>, Status> {
+        Ok(Response::new(self.owner.drain(request.into_inner()).await))
+    }
+}
+
+#[cfg(unix)]
+pub async fn serve_uds<O: ComponentDrainOwner>(
+    socket: &Path,
+    owner: Arc<O>,
+    cancel: CancellationToken,
+) -> base::exception::GlobalResult<()> {
+    use base::futures::stream;
+
+    if !socket.is_absolute()
+        || socket.components().any(|part| {
+            matches!(
+                part,
+                std::path::Component::CurDir | std::path::Component::ParentDir
+            )
+        })
+    {
+        return Err(base::exception::GlobalError::new_sys_error(
+            "component management socket must be an absolute normalized path",
+            |_| {},
+        ));
+    }
+    if let Some(parent) = socket.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| base::exception::GlobalError::from_external_error(error, |_| {}))?;
+    }
+    let listener = base::tokio::net::UnixListener::bind(socket)
+        .map_err(|error| base::exception::GlobalError::from_external_error(error, |_| {}))?;
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o600))
+        .map_err(|error| base::exception::GlobalError::from_external_error(error, |_| {}))?;
+    let incoming = stream::unfold(listener, |listener| async move {
+        Some((listener.accept().await.map(|(stream, _)| stream), listener))
+    });
+    let result = tonic::transport::Server::builder()
+        .add_service(ComponentManagementServer::new(ComponentManagementRpc::new(
+            owner,
+        )))
+        .serve_with_incoming_shutdown(incoming, async move { cancel.cancelled().await })
+        .await;
+    match std::fs::remove_file(socket) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(base::exception::GlobalError::from_external_error(
+                error,
+                |_| {},
+            ));
+        }
+    }
+    result.map_err(|error| base::exception::GlobalError::from_external_error(error, |_| {}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct TestBehavior {
+        accepting: AtomicBool,
+        drained: AtomicBool,
+        release: Option<Arc<base::tokio::sync::Notify>>,
+        drain_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ComponentDrainBehavior for TestBehavior {
+        fn supported(&self) -> bool {
+            true
+        }
+        fn close_admission(&self) {
+            self.accepting.store(false, Ordering::Release);
+        }
+        async fn is_drained(&self) -> bool {
+            self.drained.load(Ordering::Acquire)
+        }
+        async fn drain_owned_resources(&self) -> Result<(), &'static str> {
+            self.drain_calls.fetch_add(1, Ordering::AcqRel);
+            if let Some(release) = &self.release {
+                release.notified().await;
+            }
+            self.drained.store(true, Ordering::Release);
+            Ok(())
+        }
+    }
+
+    fn future_deadline() -> i64 {
+        now_ms() + 10_000
+    }
+
+    #[tokio::test]
+    async fn replay_keeps_generation_and_conflicting_operation_is_rejected() {
+        let release = Arc::new(base::tokio::sync::Notify::new());
+        let behavior = Arc::new(TestBehavior {
+            accepting: AtomicBool::new(true),
+            drained: AtomicBool::new(false),
+            release: Some(release.clone()),
+            drain_calls: AtomicUsize::new(0),
+        });
+        let owner = ManagedDrainOwner::new("stream", behavior.clone());
+        let request = PrepareForUpgradeRequest {
+            operation_id: "op-1".into(),
+            component_id: "stream".into(),
+            deadline_epoch_ms: future_deadline(),
+        };
+        let first = owner.prepare_for_upgrade(request.clone()).await;
+        let replay = owner.prepare_for_upgrade(request).await;
+        let expired_replay = owner
+            .prepare_for_upgrade(PrepareForUpgradeRequest {
+                operation_id: "op-1".into(),
+                component_id: "stream".into(),
+                deadline_epoch_ms: now_ms() - 1,
+            })
+            .await;
+        let conflict = owner
+            .prepare_for_upgrade(PrepareForUpgradeRequest {
+                operation_id: "op-2".into(),
+                component_id: "stream".into(),
+                deadline_epoch_ms: future_deadline(),
+            })
+            .await;
+        let cross_target = owner
+            .prepare_for_upgrade(PrepareForUpgradeRequest {
+                operation_id: "op-1".into(),
+                component_id: "session".into(),
+                deadline_epoch_ms: future_deadline(),
+            })
+            .await;
+        assert_eq!(first.outcome, ComponentDrainOutcome::Accepted as i32);
+        assert_eq!(
+            replay.outcome,
+            ComponentDrainOutcome::AlreadyDraining as i32
+        );
+        assert_eq!(
+            expired_replay.outcome,
+            ComponentDrainOutcome::AlreadyDraining as i32
+        );
+        assert_eq!(
+            conflict.outcome,
+            ComponentDrainOutcome::OperationConflict as i32
+        );
+        assert_eq!(
+            cross_target.outcome,
+            ComponentDrainOutcome::OperationConflict as i32
+        );
+        assert!(!behavior.accepting.load(Ordering::Acquire));
+        release.notify_one();
+        let first_drain = owner
+            .drain(DrainRequest {
+                operation_id: "op-1".into(),
+                component_id: "stream".into(),
+                deadline_epoch_ms: future_deadline(),
+            })
+            .await;
+        let replay_drain = owner
+            .drain(DrainRequest {
+                operation_id: "op-1".into(),
+                component_id: "stream".into(),
+                deadline_epoch_ms: future_deadline(),
+            })
+            .await;
+        assert_eq!(
+            first_drain.outcome,
+            ComponentDrainOutcome::AlreadyDrained as i32
+        );
+        assert_eq!(
+            replay_drain.outcome,
+            ComponentDrainOutcome::AlreadyDrained as i32
+        );
+        assert_eq!(behavior.drain_calls.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn deadline_does_not_reopen_admission() {
+        let behavior = Arc::new(TestBehavior {
+            accepting: AtomicBool::new(true),
+            drained: AtomicBool::new(false),
+            release: Some(Arc::new(base::tokio::sync::Notify::new())),
+            drain_calls: AtomicUsize::new(0),
+        });
+        let owner = ManagedDrainOwner::new("avai", behavior.clone());
+        owner
+            .prepare_for_upgrade(PrepareForUpgradeRequest {
+                operation_id: "op-1".into(),
+                component_id: "avai".into(),
+                deadline_epoch_ms: future_deadline(),
+            })
+            .await;
+        let response = owner
+            .drain(DrainRequest {
+                operation_id: "op-1".into(),
+                component_id: "avai".into(),
+                deadline_epoch_ms: now_ms() + 10,
+            })
+            .await;
+        assert_eq!(response.owner_state, ComponentOwnerState::Draining as i32);
+        assert_eq!(
+            response.outcome,
+            ComponentDrainOutcome::DeadlineExceeded as i32
+        );
+        assert!(!behavior.accepting.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn unsupported_busy_and_component_route_isolation_are_typed() {
+        for component_id in ["guard", "session", "stream", "avai"] {
+            let unsupported = UnsupportedDrainOwner::new(component_id);
+            let response = unsupported
+                .prepare_for_upgrade(PrepareForUpgradeRequest {
+                    operation_id: "op-1".into(),
+                    component_id: component_id.into(),
+                    deadline_epoch_ms: future_deadline(),
+                })
+                .await;
+            assert_eq!(response.outcome, ComponentDrainOutcome::Unsupported as i32);
+            let cross_target = unsupported
+                .prepare_for_upgrade(PrepareForUpgradeRequest {
+                    operation_id: "op-1".into(),
+                    component_id: "other".into(),
+                    deadline_epoch_ms: future_deadline(),
+                })
+                .await;
+            assert_eq!(
+                cross_target.outcome,
+                ComponentDrainOutcome::OperationConflict as i32
+            );
+        }
+
+        let owner = ManagedDrainOwner::new(
+            "stream",
+            Arc::new(TestBehavior {
+                accepting: AtomicBool::new(true),
+                drained: AtomicBool::new(false),
+                release: None,
+                drain_calls: AtomicUsize::new(0),
+            }),
+        );
+        let busy = owner
+            .drain(DrainRequest {
+                operation_id: "op-1".into(),
+                component_id: "stream".into(),
+                deadline_epoch_ms: future_deadline(),
+            })
+            .await;
+        assert_eq!(busy.owner_state, ComponentOwnerState::Accepting as i32);
+        assert_eq!(busy.outcome, ComponentDrainOutcome::Busy as i32);
+    }
+}

--- a/shared/nodec/src/lib.rs
+++ b/shared/nodec/src/lib.rs
@@ -20,6 +20,7 @@ use gmv_protocol::guard::v1::{
 use sys_metrics::HostMetricsCollector;
 use tokio_stream::wrappers::ReceiverStream;
 
+pub mod component_management;
 pub mod error;
 pub mod error_code;
 

--- a/shared/protocol/build.rs
+++ b/shared/protocol/build.rs
@@ -13,6 +13,7 @@ fn main() -> io::Result<()> {
         proto_root.join("stream/v1/control.proto"),
         proto_root.join("avai/v1/control.proto"),
         proto_root.join("center_agent/v1/control.proto"),
+        proto_root.join("component_management/v1/management.proto"),
     ];
 
     println!("cargo:rerun-if-changed=build.rs");

--- a/shared/protocol/proto/component_management/v1/management.proto
+++ b/shared/protocol/proto/component_management/v1/management.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package gmv.component_management.v1;
+
+service ComponentManagement {
+  rpc PrepareForUpgrade(PrepareForUpgradeRequest) returns (ComponentDrainResponse);
+  rpc Drain(DrainRequest) returns (ComponentDrainResponse);
+}
+
+message PrepareForUpgradeRequest {
+  string operation_id = 1;
+  string component_id = 2;
+  int64 deadline_epoch_ms = 3;
+}
+
+message DrainRequest {
+  string operation_id = 1;
+  string component_id = 2;
+  int64 deadline_epoch_ms = 3;
+}
+
+message ComponentDrainResponse {
+  string operation_id = 1;
+  string component_id = 2;
+  ComponentOwnerState owner_state = 3;
+  ComponentDrainOutcome outcome = 4;
+  string stable_error_code = 5;
+  int64 observed_at_epoch_ms = 6;
+}
+
+enum ComponentOwnerState {
+  COMPONENT_OWNER_STATE_UNSPECIFIED = 0;
+  COMPONENT_OWNER_STATE_ACCEPTING = 1;
+  COMPONENT_OWNER_STATE_DRAINING = 2;
+  COMPONENT_OWNER_STATE_DRAINED = 3;
+  COMPONENT_OWNER_STATE_BLOCKED = 4;
+}
+
+enum ComponentDrainOutcome {
+  COMPONENT_DRAIN_OUTCOME_UNSPECIFIED = 0;
+  COMPONENT_DRAIN_OUTCOME_ACCEPTED = 1;
+  COMPONENT_DRAIN_OUTCOME_ALREADY_DRAINING = 2;
+  COMPONENT_DRAIN_OUTCOME_DRAINED = 3;
+  COMPONENT_DRAIN_OUTCOME_ALREADY_DRAINED = 4;
+  COMPONENT_DRAIN_OUTCOME_UNSUPPORTED = 5;
+  COMPONENT_DRAIN_OUTCOME_BUSY = 6;
+  COMPONENT_DRAIN_OUTCOME_DEADLINE_EXCEEDED = 7;
+  COMPONENT_DRAIN_OUTCOME_OPERATION_CONFLICT = 8;
+  COMPONENT_DRAIN_OUTCOME_INTERNAL_FAILURE = 9;
+}

--- a/shared/protocol/src/lib.rs
+++ b/shared/protocol/src/lib.rs
@@ -39,3 +39,9 @@ pub mod gmv_center_agent {
 }
 
 pub mod gmv_center_agent_mqtt;
+
+pub mod component_management {
+    pub mod v1 {
+        tonic::include_proto!("gmv.component_management.v1");
+    }
+}

--- a/shared/protocol/tests/descriptor_contract.rs
+++ b/shared/protocol/tests/descriptor_contract.rs
@@ -139,9 +139,120 @@ fn descriptor_contains_versioned_packages() {
         "gmv.stream.v1",
         "gmv.avai.v1",
         "gmv.center_agent.v1",
+        "gmv.component_management.v1",
     ] {
         assert!(packages.contains(&package), "missing package {package}");
     }
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct LegacyComponentDrainResponse {
+    #[prost(string, tag = "1")]
+    operation_id: String,
+    #[prost(string, tag = "2")]
+    component_id: String,
+    #[prost(int32, tag = "3")]
+    owner_state: i32,
+    #[prost(int32, tag = "4")]
+    outcome: i32,
+    #[prost(string, tag = "5")]
+    stable_error_code: String,
+}
+
+#[test]
+fn component_management_contract_is_minimal_additive_and_wire_compatible() {
+    let descriptor = descriptor();
+    let file = descriptor_file(&descriptor, "gmv.component_management.v1");
+    let service = file
+        .service
+        .iter()
+        .find(|value| value.name.as_deref() == Some("ComponentManagement"))
+        .unwrap();
+    assert_eq!(
+        service
+            .method
+            .iter()
+            .filter_map(|value| value.name.as_deref())
+            .collect::<Vec<_>>(),
+        ["PrepareForUpgrade", "Drain"]
+    );
+    for message_name in ["PrepareForUpgradeRequest", "DrainRequest"] {
+        let message = descriptor_message(file, message_name);
+        assert_eq!(message.field.len(), 3);
+        assert_eq!(descriptor_field_number(message, "operation_id"), Some(1));
+        assert_eq!(descriptor_field_number(message, "component_id"), Some(2));
+        assert_eq!(
+            descriptor_field_number(message, "deadline_epoch_ms"),
+            Some(3)
+        );
+    }
+
+    let current = gmv_protocol::component_management::v1::ComponentDrainResponse {
+        operation_id: "op-1".into(),
+        component_id: "stream".into(),
+        owner_state: 2,
+        outcome: 1,
+        stable_error_code: String::new(),
+        observed_at_epoch_ms: 123,
+    };
+    let legacy = LegacyComponentDrainResponse::decode(current.encode_to_vec().as_slice()).unwrap();
+    assert_eq!(legacy.operation_id, "op-1");
+    let decoded = gmv_protocol::component_management::v1::ComponentDrainResponse::decode(
+        legacy.encode_to_vec().as_slice(),
+    )
+    .unwrap();
+    assert_eq!(decoded.observed_at_epoch_ms, 0);
+}
+
+#[test]
+fn component_management_fails_closed_for_future_enums_and_has_no_remote_authority() {
+    use gmv_protocol::component_management::v1::{ComponentDrainOutcome, ComponentOwnerState};
+    assert!(ComponentOwnerState::try_from(99).is_err());
+    assert!(ComponentDrainOutcome::try_from(99).is_err());
+
+    let descriptor = descriptor();
+    let file = descriptor_file(&descriptor, "gmv.component_management.v1");
+    let forbidden = [
+        "shell",
+        "argv",
+        "command",
+        "executable",
+        "path",
+        "unit",
+        "script",
+        "hook",
+        "socket",
+        "endpoint",
+        "pid",
+        "resource",
+    ];
+    for message in &file.message_type {
+        for field in &message.field {
+            let name = field
+                .name
+                .as_deref()
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            assert!(
+                !forbidden.iter().any(|value| name.contains(value)),
+                "forbidden authority field {name}"
+            );
+        }
+    }
+    let envelope = descriptor_file(&descriptor, "gmv.center_agent.v1");
+    assert!(
+        envelope
+            .message_type
+            .iter()
+            .flat_map(|message| &message.field)
+            .all(|field| {
+                !field
+                    .type_name
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("component_management")
+            })
+    );
 }
 
 #[test]

--- a/stream/config.yml
+++ b/stream/config.yml
@@ -17,6 +17,8 @@ guard:
 server:
   installation_id: local-installation #一套独立安装/升级边界的稳定ID，与同机gmv-center-agent/Avai保持一致
   name: s1 #服务标识身份,流媒体集群唯一标识，guard注册时节点ID
+  management_component_id: stream
+  management_socket: /run/gmv/stream-management.sock
   http:
     listen_addr: 0.0.0.0:28570 #本机HTTP实际监听地址
     public_url: http://192.168.0.9:28570 #播放、WebSocket和节点HTTP endpoint使用的完整对外URL

--- a/stream/src/app.rs
+++ b/stream/src/app.rs
@@ -18,6 +18,7 @@ use crate::guard_integration::{
     StreamControlAdapter, StreamControlRpc, StreamGuardNode, init_guard_channel,
     init_guard_event_sender,
 };
+use gmv_nodec::component_management::{ManagedDrainOwner, serve_uds};
 use gmv_nodec::{NodeReporter, NodeReporterConfig, generate_instance_id};
 use gmv_protocol::common::v1::{Endpoint, EndpointMode};
 use gmv_protocol::guard::v1::NodeResourceSnapshot;
@@ -96,6 +97,8 @@ impl Daemon<StreamBootstrap> for App {
             media_conf,
         } = bootstrap;
         let node_name = self.conf.name.clone();
+        let management_socket = self.conf.management_socket.clone();
+        let management_component_id = self.conf.management_component_id.clone();
         let installation_id = self.conf.installation_id.clone();
         let (http_public_tls, http_public_host, http_public_port) =
             self.conf.http.public_endpoint().map_err(|message| {
@@ -158,6 +161,19 @@ impl Daemon<StreamBootstrap> for App {
                     .with_media_endpoints(media_endpoints.clone())
                     .with_media_tx(tx.clone()),
             );
+            if let Some(socket) = management_socket {
+                let owner = Arc::new(ManagedDrainOwner::new(
+                    management_component_id,
+                    Arc::new(control_rpc.drain_behavior(media_endpoints.clone())),
+                ));
+                let management_cancel = network_rt.cancel.clone();
+                network_rt.spawn("stream-component-management", async move {
+                    if let Err(error) = serve_uds(&socket, owner, management_cancel).await {
+                        error!("stream component management failed: {error}");
+                        GlobalRuntime::request_shutdown_with_error();
+                    }
+                })?;
+            }
             let server_rpc = control_rpc.clone();
             network_rt.spawn("stream-control-rpc", async move {
                 base::log::debug!(

--- a/stream/src/general/cfg.rs
+++ b/stream/src/general/cfg.rs
@@ -67,6 +67,10 @@ pub struct ServerConf {
     pub http: HttpServerConf,
     pub grpc: GrpcServerConf,
     pub media: MediaServerConf,
+    #[serde(default)]
+    pub management_socket: Option<PathBuf>,
+    #[serde(default = "default_management_component_id")]
+    pub management_component_id: String,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -307,6 +311,20 @@ impl ServerConf {
         if self.name.trim().is_empty() {
             return Err("server.name must not be empty".to_string());
         }
+        if self.management_component_id.trim().is_empty() {
+            return Err("server.management_component_id must not be empty".to_string());
+        }
+        if let Some(socket) = &self.management_socket
+            && (!socket.is_absolute()
+                || socket.components().any(|part| {
+                    matches!(
+                        part,
+                        std::path::Component::CurDir | std::path::Component::ParentDir
+                    )
+                }))
+        {
+            return Err("server.management_socket must be an absolute normalized path".to_string());
+        }
         if self.http.listen_addr.port() == 0 {
             return Err("server.http.listen_addr port must not be zero".to_string());
         }
@@ -334,6 +352,10 @@ impl ServerConf {
             self.grpc.listen_addr.port(),
         )
     }
+}
+
+fn default_management_component_id() -> String {
+    "stream".to_string()
 }
 
 fn validate_tls_files(

--- a/stream/src/guard_integration.rs
+++ b/stream/src/guard_integration.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    sync::atomic::{AtomicBool, AtomicU64, Ordering},
+    sync::atomic::{AtomicU64, Ordering},
     sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
@@ -18,7 +18,10 @@ use gmv_domain::info::obj::{
     StreamRecordInfo,
 };
 use gmv_domain::info::output::{OutputEnum, OutputKind};
-use gmv_nodec::{NodeEventSender, component_management::ComponentDrainBehavior};
+use gmv_nodec::{
+    NodeEventSender,
+    component_management::{AdmissionBarrier, ComponentDrainBehavior},
+};
 use gmv_protocol::common::v1::{
     Endpoint, EndpointMode, ErrorDetail, NodeIdentity, NodeKind, OperationRef, ResourceRef,
 };
@@ -349,21 +352,33 @@ impl StreamGuardNode {
 #[derive(Clone)]
 pub struct StreamControlRpc {
     inner: Arc<Mutex<StreamControlAdapter>>,
-    accepting: Arc<AtomicBool>,
+    admission: AdmissionBarrier,
+    #[cfg(test)]
+    admission_pauses: Arc<std::sync::Mutex<HashMap<&'static str, AdmissionPause>>>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct AdmissionPause {
+    entered: Arc<base::tokio::sync::Semaphore>,
+    release: Arc<base::tokio::sync::Semaphore>,
+    committed_stream_id: String,
 }
 
 pub struct StreamDrainBehavior {
     control: StreamControlRpc,
-    accepting: Arc<AtomicBool>,
+    admission: AdmissionBarrier,
     media_endpoints: Arc<MediaEndpointManager>,
 }
 
 impl StreamControlRpc {
     pub fn new(adapter: StreamControlAdapter) -> Self {
-        let accepting = adapter.accepting.clone();
+        let admission = adapter.admission.clone();
         Self {
             inner: Arc::new(Mutex::new(adapter)),
-            accepting,
+            admission,
+            #[cfg(test)]
+            admission_pauses: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -376,9 +391,33 @@ impl StreamControlRpc {
         media_endpoints: Arc<MediaEndpointManager>,
     ) -> StreamDrainBehavior {
         StreamDrainBehavior {
-            accepting: self.accepting.clone(),
+            admission: self.admission.clone(),
             control: self.clone(),
             media_endpoints,
+        }
+    }
+
+    #[cfg(test)]
+    async fn pause_after_admission(&self, operation: &'static str) {
+        let pause = self
+            .admission_pauses
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(operation)
+            .cloned();
+        if let Some(pause) = pause {
+            pause.entered.add_permits(1);
+            pause.release.acquire().await.unwrap().forget();
+            self.inner.lock().await.streams.insert(
+                pause.committed_stream_id,
+                StreamRuntime {
+                    lease_id: "admission-race-lease".into(),
+                    route_id: "admission-race-route".into(),
+                    endpoints: vec![],
+                    state: StreamState::Receiving,
+                    primary_output_format: String::new(),
+                },
+            );
         }
     }
 }
@@ -390,7 +429,15 @@ impl ComponentDrainBehavior for StreamDrainBehavior {
     }
 
     fn close_admission(&self) {
-        self.accepting.store(false, Ordering::Release);
+        self.admission.close();
+    }
+
+    fn in_flight_admissions(&self) -> usize {
+        self.admission.in_flight()
+    }
+
+    async fn wait_for_admissions(&self) {
+        self.admission.wait_for_zero().await;
     }
 
     async fn is_drained(&self) -> bool {
@@ -549,14 +596,16 @@ impl StreamControl for StreamControlRpc {
             "stream_control.init_media_ext, req: payload_bytes={}",
             request.payload_json.len()
         );
-        if !self.accepting.load(Ordering::Acquire) {
+        let Some(_permit) = self.admission.acquire() else {
             return Ok(tonic::Response::new(StreamUnitResponse {
                 error: Some(error(
                     "component_draining",
                     "stream is draining for upgrade",
                 )),
             }));
-        }
+        };
+        #[cfg(test)]
+        self.pause_after_admission("init_media_ext").await;
         Ok(tonic::Response::new(stream_unit_response(
             decode_payload::<MediaMap>(&request.payload_json).and_then(|value| {
                 Register::init_media_ext(value.ssrc, value.ext).map_err(detail_from_error)
@@ -632,7 +681,7 @@ impl StreamControl for StreamControlRpc {
             "stream_control.broadcast_open, req: payload_bytes={}",
             request.payload_json.len()
         );
-        if !self.inner.lock().await.accepting.load(Ordering::Acquire) {
+        let Some(_permit) = self.admission.acquire() else {
             return Ok(tonic::Response::new(StreamJsonResponse {
                 payload_json: vec![],
                 error: Some(error(
@@ -640,7 +689,9 @@ impl StreamControl for StreamControlRpc {
                     "stream is draining for upgrade",
                 )),
             }));
-        }
+        };
+        #[cfg(test)]
+        self.pause_after_admission("broadcast_open").await;
         Ok(tonic::Response::new(
             match decode_payload::<BroadcastOpenReq>(&request.payload_json) {
                 Ok(value) => match BroadcastManager::open(value).await {
@@ -667,6 +718,14 @@ impl StreamControl for StreamControlRpc {
             "stream_control.broadcast_configure_leg, req: payload_bytes={}",
             request.payload_json.len()
         );
+        let Some(_permit) = self.admission.acquire() else {
+            return Ok(tonic::Response::new(StreamUnitResponse {
+                error: Some(error(
+                    "component_draining",
+                    "stream is draining for upgrade",
+                )),
+            }));
+        };
         let result = match decode_payload::<BroadcastConfigureLegReq>(&request.payload_json) {
             Ok(value) => BroadcastManager::configure_leg(value)
                 .await
@@ -746,7 +805,7 @@ pub struct StreamControlAdapter {
     restart_close_watches: HashMap<String, RestartCloseWatch>,
     media_tx: Option<mpsc::Sender<u32>>,
     media_endpoints: Option<Arc<MediaEndpointManager>>,
-    accepting: Arc<AtomicBool>,
+    admission: AdmissionBarrier,
 }
 
 #[derive(Debug, Clone)]
@@ -869,7 +928,7 @@ impl StreamControlAdapter {
             restart_close_watches: HashMap::new(),
             media_tx: None,
             media_endpoints: None,
-            accepting: Arc::new(AtomicBool::new(true)),
+            admission: AdmissionBarrier::default(),
         }
     }
 
@@ -888,7 +947,7 @@ impl StreamControlAdapter {
     }
 
     pub async fn start_receive(&mut self, request: StartReceiveRequest) -> StartReceiveResponse {
-        if !self.accepting.load(Ordering::Acquire) {
+        let Some(_permit) = self.admission.acquire() else {
             return start_response(
                 &request.stream_id,
                 StreamState::Failed,
@@ -898,7 +957,7 @@ impl StreamControlAdapter {
                     "stream is draining for upgrade",
                 )),
             );
-        }
+        };
         let transport = MediaTransport::try_from(request.media_transport)
             .unwrap_or(MediaTransport::Unspecified);
         if transport == MediaTransport::Unspecified && request.media_transport != 0 {
@@ -1040,7 +1099,7 @@ impl StreamControlAdapter {
         &self,
         request: ConfigureReceiveTransportRequest,
     ) -> ConfigureReceiveTransportResponse {
-        if !self.accepting.load(Ordering::Acquire) {
+        let Some(_permit) = self.admission.acquire() else {
             return configure_transport_response(
                 MediaTransportState::Failed,
                 None,
@@ -1050,7 +1109,7 @@ impl StreamControlAdapter {
                     "stream is draining for upgrade",
                 )),
             );
-        }
+        };
         let transport = MediaTransport::try_from(request.media_transport)
             .unwrap_or(MediaTransport::Unspecified);
         let local_endpoint = self.streams.get(&request.stream_id).and_then(|stream| {
@@ -1655,7 +1714,7 @@ impl StreamControlAdapter {
     }
 
     pub fn create_output(&mut self, request: CreateOutputRequest) -> CreateOutputResponse {
-        if !self.accepting.load(Ordering::Acquire) {
+        let Some(_permit) = self.admission.acquire() else {
             return CreateOutputResponse {
                 output_id: String::new(),
                 endpoints: vec![],
@@ -1665,7 +1724,7 @@ impl StreamControlAdapter {
                 )),
                 output: None,
             };
-        }
+        };
         self.prune_terminal_subscriptions(now_ms());
         if self.streams.get(&request.stream_id).is_some_and(|stream| {
             matches!(stream.state, StreamState::Stopping | StreamState::Stopped)
@@ -1942,14 +2001,14 @@ impl StreamControlAdapter {
     }
 
     pub fn init_media(&mut self, request: StreamJsonRequest) -> StreamUnitResponse {
-        if !self.accepting.load(Ordering::Acquire) {
+        let Some(_permit) = self.admission.acquire() else {
             return StreamUnitResponse {
                 error: Some(error(
                     "component_draining",
                     "stream is draining for upgrade",
                 )),
             };
-        }
+        };
         let media_tx = match self.media_tx.clone() {
             Some(media_tx) => media_tx,
             None => {
@@ -2367,6 +2426,10 @@ mod tests {
     use crate::general::cfg::{MediaListenerConf, MediaListenerMode, MediaPortRange};
     use crate::io::media_endpoint::{MediaBootstrap, MediaEndpointManager, find_free_test_range};
     use base::utils::rt::GlobalRuntime;
+    use gmv_nodec::component_management::{ComponentDrainOwner, ManagedDrainOwner};
+    use gmv_protocol::component_management::v1::{
+        ComponentDrainOutcome, ComponentOwnerState, DrainRequest, PrepareForUpgradeRequest,
+    };
     use std::net::{IpAddr, Ipv4Addr, TcpListener, UdpSocket};
 
     #[test]
@@ -3098,7 +3161,7 @@ mod tests {
             node.identity.clone(),
             endpoint("rtp", "rtp", "127.0.0.1", 30000),
         );
-        control.accepting.store(false, Ordering::Release);
+        control.admission.close();
         let response = control
             .start_receive(StartReceiveRequest {
                 operation: Some(operation("op-draining")),
@@ -3114,5 +3177,135 @@ mod tests {
             .await;
         assert_eq!(response.error.unwrap().code, "component_draining");
         assert!(control.resource_snapshot().resources.is_empty());
+    }
+
+    fn stream_drain_test_rpc() -> (StreamControlRpc, Arc<MediaEndpointManager>) {
+        let runtime = GlobalRuntime::get_main_runtime();
+        let port = find_free_test_range(1).start;
+        let manager = MediaEndpointManager::new(
+            runtime,
+            MediaListenerConf {
+                mode: MediaListenerMode::Multi,
+                bind_ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+                advertised_host: "127.0.0.1".into(),
+                single_port: 0,
+                port_range: MediaPortRange {
+                    start: port,
+                    end: port,
+                },
+                reservation_timeout_secs: 60,
+            },
+            MediaBootstrap::Multi,
+        )
+        .unwrap();
+        let node = StreamGuardNode::new(
+            "stream-drain-test",
+            "instance-drain-test",
+            "127.0.0.1",
+            "http://127.0.0.1",
+            0,
+            false,
+            u32::from(port),
+        );
+        let adapter = StreamControlAdapter::new(
+            node.identity,
+            endpoint("rtp", "rtp", "127.0.0.1", u32::from(port)),
+        )
+        .with_media_endpoints(manager.clone());
+        (StreamControlRpc::new(adapter), manager)
+    }
+
+    fn install_admission_pause(
+        rpc: &StreamControlRpc,
+        operation: &'static str,
+        stream_id: &str,
+    ) -> (
+        Arc<base::tokio::sync::Semaphore>,
+        Arc<base::tokio::sync::Semaphore>,
+    ) {
+        let entered = Arc::new(base::tokio::sync::Semaphore::new(0));
+        let release = Arc::new(base::tokio::sync::Semaphore::new(0));
+        rpc.admission_pauses
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(
+                operation,
+                AdmissionPause {
+                    entered: entered.clone(),
+                    release: release.clone(),
+                    committed_stream_id: stream_id.into(),
+                },
+            );
+        (entered, release)
+    }
+
+    async fn assert_stream_admission_race(operation: &'static str) {
+        let (rpc, manager) = stream_drain_test_rpc();
+        let (entered, release) = install_admission_pause(&rpc, operation, operation);
+        let request_rpc = rpc.clone();
+        let request = base::tokio::spawn(async move {
+            invoke_admission_path(request_rpc, operation).await;
+        });
+        entered.acquire().await.unwrap().forget();
+        assert_eq!(rpc.admission.in_flight(), 1);
+
+        let owner = ManagedDrainOwner::new("stream", Arc::new(rpc.drain_behavior(manager)));
+        let prepared = owner
+            .prepare_for_upgrade(PrepareForUpgradeRequest {
+                operation_id: format!("op-{operation}"),
+                component_id: "stream".into(),
+                deadline_epoch_ms: now_ms() + 10_000,
+            })
+            .await;
+        assert_eq!(prepared.owner_state, ComponentOwnerState::Draining as i32);
+        assert_eq!(prepared.outcome, ComponentDrainOutcome::Accepted as i32);
+        assert_eq!(
+            invoke_admission_path(rpc.clone(), operation).await.code,
+            "component_draining"
+        );
+
+        release.add_permits(1);
+        request.await.unwrap();
+        let drained = owner
+            .drain(DrainRequest {
+                operation_id: format!("op-{operation}"),
+                component_id: "stream".into(),
+                deadline_epoch_ms: now_ms() + 10_000,
+            })
+            .await;
+        assert_eq!(drained.owner_state, ComponentOwnerState::Drained as i32);
+        assert_eq!(rpc.admission.in_flight(), 0);
+        assert!(rpc.inner.lock().await.streams.is_empty());
+        assert!(rpc.admission.acquire().is_none());
+    }
+
+    async fn invoke_admission_path(rpc: StreamControlRpc, operation: &'static str) -> ErrorDetail {
+        match operation {
+            "broadcast_open" => rpc
+                .broadcast_open(tonic::Request::new(StreamJsonRequest::default()))
+                .await
+                .unwrap()
+                .into_inner()
+                .error
+                .unwrap(),
+            "init_media_ext" => rpc
+                .init_media_ext(tonic::Request::new(StreamJsonRequest::default()))
+                .await
+                .unwrap()
+                .into_inner()
+                .error
+                .unwrap(),
+            _ => unreachable!(),
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_admission_cannot_cross_terminal_drain() {
+        assert_stream_admission_race("broadcast_open").await;
+    }
+
+    #[tokio::test]
+    async fn register_media_admission_cannot_cross_terminal_drain() {
+        assert_stream_admission_race("init_media_ext").await;
     }
 }

--- a/stream/src/guard_integration.rs
+++ b/stream/src/guard_integration.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
     sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
@@ -18,7 +18,7 @@ use gmv_domain::info::obj::{
     StreamRecordInfo,
 };
 use gmv_domain::info::output::{OutputEnum, OutputKind};
-use gmv_nodec::NodeEventSender;
+use gmv_nodec::{NodeEventSender, component_management::ComponentDrainBehavior};
 use gmv_protocol::common::v1::{
     Endpoint, EndpointMode, ErrorDetail, NodeIdentity, NodeKind, OperationRef, ResourceRef,
 };
@@ -349,17 +349,83 @@ impl StreamGuardNode {
 #[derive(Clone)]
 pub struct StreamControlRpc {
     inner: Arc<Mutex<StreamControlAdapter>>,
+    accepting: Arc<AtomicBool>,
+}
+
+pub struct StreamDrainBehavior {
+    control: StreamControlRpc,
+    accepting: Arc<AtomicBool>,
+    media_endpoints: Arc<MediaEndpointManager>,
 }
 
 impl StreamControlRpc {
     pub fn new(adapter: StreamControlAdapter) -> Self {
+        let accepting = adapter.accepting.clone();
         Self {
             inner: Arc::new(Mutex::new(adapter)),
+            accepting,
         }
     }
 
     pub async fn resource_snapshot(&self) -> NodeResourceSnapshot {
         self.inner.lock().await.resource_snapshot()
+    }
+
+    pub fn drain_behavior(
+        &self,
+        media_endpoints: Arc<MediaEndpointManager>,
+    ) -> StreamDrainBehavior {
+        StreamDrainBehavior {
+            accepting: self.accepting.clone(),
+            control: self.clone(),
+            media_endpoints,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl ComponentDrainBehavior for StreamDrainBehavior {
+    fn supported(&self) -> bool {
+        true
+    }
+
+    fn close_admission(&self) {
+        self.accepting.store(false, Ordering::Release);
+    }
+
+    async fn is_drained(&self) -> bool {
+        let control_empty = {
+            let control = self.control.inner.lock().await;
+            control.streams.is_empty() && control.outputs.is_empty()
+        };
+        let stats = self.media_endpoints.stats_snapshot();
+        control_empty
+            && Register::active_stream_count() == 0
+            && BroadcastManager::active_session_count() == 0
+            && stats.listening == 0
+            && stats.confirmed == 0
+            && stats.releasing == 0
+    }
+
+    async fn drain_owned_resources(&self) -> Result<(), &'static str> {
+        let stream_ids = {
+            let mut control = self.control.inner.lock().await;
+            let ids = control.streams.keys().cloned().collect::<Vec<_>>();
+            control.streams.clear();
+            control.outputs.clear();
+            ids
+        };
+        for stream_id in stream_ids {
+            Register::close_stream_by_id(&stream_id);
+        }
+        BroadcastManager::drain_all()
+            .await
+            .map_err(|_| "stream_broadcast_drain_failed")?;
+        self.media_endpoints
+            .shutdown()
+            .await
+            .map_err(|_| "stream_endpoint_drain_failed")?;
+        Ok(())
     }
 }
 
@@ -483,6 +549,14 @@ impl StreamControl for StreamControlRpc {
             "stream_control.init_media_ext, req: payload_bytes={}",
             request.payload_json.len()
         );
+        if !self.accepting.load(Ordering::Acquire) {
+            return Ok(tonic::Response::new(StreamUnitResponse {
+                error: Some(error(
+                    "component_draining",
+                    "stream is draining for upgrade",
+                )),
+            }));
+        }
         Ok(tonic::Response::new(stream_unit_response(
             decode_payload::<MediaMap>(&request.payload_json).and_then(|value| {
                 Register::init_media_ext(value.ssrc, value.ext).map_err(detail_from_error)
@@ -558,6 +632,15 @@ impl StreamControl for StreamControlRpc {
             "stream_control.broadcast_open, req: payload_bytes={}",
             request.payload_json.len()
         );
+        if !self.inner.lock().await.accepting.load(Ordering::Acquire) {
+            return Ok(tonic::Response::new(StreamJsonResponse {
+                payload_json: vec![],
+                error: Some(error(
+                    "component_draining",
+                    "stream is draining for upgrade",
+                )),
+            }));
+        }
         Ok(tonic::Response::new(
             match decode_payload::<BroadcastOpenReq>(&request.payload_json) {
                 Ok(value) => match BroadcastManager::open(value).await {
@@ -663,6 +746,7 @@ pub struct StreamControlAdapter {
     restart_close_watches: HashMap<String, RestartCloseWatch>,
     media_tx: Option<mpsc::Sender<u32>>,
     media_endpoints: Option<Arc<MediaEndpointManager>>,
+    accepting: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Clone)]
@@ -785,6 +869,7 @@ impl StreamControlAdapter {
             restart_close_watches: HashMap::new(),
             media_tx: None,
             media_endpoints: None,
+            accepting: Arc::new(AtomicBool::new(true)),
         }
     }
 
@@ -803,6 +888,17 @@ impl StreamControlAdapter {
     }
 
     pub async fn start_receive(&mut self, request: StartReceiveRequest) -> StartReceiveResponse {
+        if !self.accepting.load(Ordering::Acquire) {
+            return start_response(
+                &request.stream_id,
+                StreamState::Failed,
+                vec![],
+                Some(error(
+                    "component_draining",
+                    "stream is draining for upgrade",
+                )),
+            );
+        }
         let transport = MediaTransport::try_from(request.media_transport)
             .unwrap_or(MediaTransport::Unspecified);
         if transport == MediaTransport::Unspecified && request.media_transport != 0 {
@@ -944,6 +1040,17 @@ impl StreamControlAdapter {
         &self,
         request: ConfigureReceiveTransportRequest,
     ) -> ConfigureReceiveTransportResponse {
+        if !self.accepting.load(Ordering::Acquire) {
+            return configure_transport_response(
+                MediaTransportState::Failed,
+                None,
+                request.remote_endpoint,
+                Some(error(
+                    "component_draining",
+                    "stream is draining for upgrade",
+                )),
+            );
+        }
         let transport = MediaTransport::try_from(request.media_transport)
             .unwrap_or(MediaTransport::Unspecified);
         let local_endpoint = self.streams.get(&request.stream_id).and_then(|stream| {
@@ -1548,6 +1655,17 @@ impl StreamControlAdapter {
     }
 
     pub fn create_output(&mut self, request: CreateOutputRequest) -> CreateOutputResponse {
+        if !self.accepting.load(Ordering::Acquire) {
+            return CreateOutputResponse {
+                output_id: String::new(),
+                endpoints: vec![],
+                error: Some(error(
+                    "component_draining",
+                    "stream is draining for upgrade",
+                )),
+                output: None,
+            };
+        }
         self.prune_terminal_subscriptions(now_ms());
         if self.streams.get(&request.stream_id).is_some_and(|stream| {
             matches!(stream.state, StreamState::Stopping | StreamState::Stopped)
@@ -1824,6 +1942,14 @@ impl StreamControlAdapter {
     }
 
     pub fn init_media(&mut self, request: StreamJsonRequest) -> StreamUnitResponse {
+        if !self.accepting.load(Ordering::Acquire) {
+            return StreamUnitResponse {
+                error: Some(error(
+                    "component_draining",
+                    "stream is draining for upgrade",
+                )),
+            };
+        }
         let media_tx = match self.media_tx.clone() {
             Some(media_tx) => media_tx,
             None => {
@@ -2955,5 +3081,38 @@ mod tests {
             .await;
         assert_eq!(response.state, StreamState::Failed as i32);
         assert_eq!(control.resource_snapshot().resources.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn upgrade_admission_rejects_new_receive_before_resource_creation() {
+        let node = StreamGuardNode::new(
+            "stream-1",
+            "inst-1",
+            "127.0.0.1",
+            "http://127.0.0.1:18080",
+            18080,
+            false,
+            30000,
+        );
+        let mut control = StreamControlAdapter::new(
+            node.identity.clone(),
+            endpoint("rtp", "rtp", "127.0.0.1", 30000),
+        );
+        control.accepting.store(false, Ordering::Release);
+        let response = control
+            .start_receive(StartReceiveRequest {
+                operation: Some(operation("op-draining")),
+                stream_id: "stream-a".into(),
+                route_id: "route-a".into(),
+                lease_id: "lease-a".into(),
+                expected_stream: Some(node.identity),
+                preferred_endpoints: vec![],
+                constraints: HashMap::new(),
+                reservation_ttl_ms: 0,
+                media_transport: MediaTransport::Udp as i32,
+            })
+            .await;
+        assert_eq!(response.error.unwrap().code, "component_draining");
+        assert!(control.resource_snapshot().resources.is_empty());
     }
 }

--- a/stream/src/io/broadcast/session.rs
+++ b/stream/src/io/broadcast/session.rs
@@ -497,6 +497,17 @@ impl BroadcastManager {
         BROADCAST_PARENTS.len()
     }
 
+    pub async fn drain_all() -> GlobalResult<()> {
+        let broadcast_ids = BROADCAST_PARENTS
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect::<Vec<_>>();
+        for broadcast_id in broadcast_ids {
+            Self::close(&broadcast_id, "").await?;
+        }
+        Ok(())
+    }
+
     pub async fn close(broadcast_id: &str, requested_leg_id: &str) -> GlobalResult<bool> {
         if !requested_leg_id.is_empty() {
             return close_leg(broadcast_id, requested_leg_id, "leg_close").await;

--- a/stream/src/state/register.rs
+++ b/stream/src/state/register.rs
@@ -1481,7 +1481,10 @@ impl Register {
     }
 
     pub fn close_stream_by_id(stream_id: &str) -> bool {
-        let arc = Self::get().inner.clone();
+        let Some(register) = REGISTER.get() else {
+            return false;
+        };
+        let arc = register.inner.clone();
         let stream_id: Arc<str> = Arc::from(stream_id);
         let Some((_, meta)) = arc.stream_metadata_map.remove(&stream_id) else {
             return false;
@@ -1545,7 +1548,9 @@ impl Register {
     }
 
     pub fn active_stream_count() -> usize {
-        Self::get().inner.stream_metadata_map.len()
+        REGISTER
+            .get()
+            .map_or(0, |register| register.inner.stream_metadata_map.len())
     }
 
     pub fn stream_id_by_ssrc(ssrc: u32) -> Option<Arc<str>> {


### PR DESCRIPTION
Implements the GMV owner-side half of epimore/gmv_docs#8 (WP-02C only).

- Adds the additive `gmv.component_management.v1` UDS contract.
- Adds stable operation identity, replay-safe generation ownership, typed outcomes/errors, deadlines, and wait-only cancellation semantics.
- Implements owner-side drain behavior for Stream and AVAI.
- Exposes honest typed `UNSUPPORTED` for Guard and Session where no safe complete owner primitive exists in this WP.
- Adds descriptor, wire, security, and deterministic drain regressions.

No activation, supervisor action, health gate, rollback, rollout, UI, or AI model activation is included.

Architecture approval: epimore/gmv_docs#8 issuecomment-5645332364.
